### PR TITLE
  Fix: Support multiple shortcode instances on the same page and add filtering capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The plugin provides the `[edmm_meeting_minutes]` shortcode, which you can use to
 - `hide_agenda`: Hides the "Agenda" column if set to `true`. Default: `false`.
 - `hide_notes`: Hides the "Notes" column if set to `true`. Default: `false`.
 - `hide_tags`: Hides the "Tags" column if set to `true`. Default: `false`.
+- `tags_label`: Custom label for the "Tags" column header (also used as the `data-label` on mobile). Default: `Tags`.
 - `held_date_format`: The format for dates of meetings that were held. Uses standard PHP date format (e.g., `Y/m/d`). Default: `Y/m/d`.
 - `not_held_date_format`: The format for dates of meetings that were not held. Uses standard PHP date format (e.g., `Y/m`). Default: `Y/m`.
 - `class`: Adds a custom CSS class to the `<table>` element. Default: empty.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The **Equalize Digital Meeting Minutes** plugin allows you to manage and display
 
 ### Features
 - Custom post type for meeting minutes.
+- Non-hierarchical taxonomy (tags) for categorising meeting minutes.
 - ACF (Advanced Custom Fields) integration for additional meeting metadata (date, agenda URL, notes URL).
 - REST API route for fetching meeting minutes.
 - A shortcode to display meeting minutes in a table with pagination.
@@ -35,10 +36,12 @@ The plugin provides the `[edmm_meeting_minutes]` shortcode, which you can use to
 
 ### Shortcode Attributes
 - `included_years`: Comma-separated list of years to include in the table (e.g., "2022,2023"). Default: empty (shows all years).
+- `tags`: Comma-separated list of meeting tag slugs to filter by (e.g., "board,annual"). Default: empty (shows all tags).
 - `hide_title`: Hides the "Title" column if set to `true`. Default: `false`.
 - `hide_date`: Hides the "Date" column if set to `true`. Default: `false`.
 - `hide_agenda`: Hides the "Agenda" column if set to `true`. Default: `false`.
 - `hide_notes`: Hides the "Notes" column if set to `true`. Default: `false`.
+- `hide_tags`: Hides the "Tags" column if set to `true`. Default: `false`.
 - `held_date_format`: The format for dates of meetings that were held. Uses standard PHP date format (e.g., `Y/m/d`). Default: `Y/m/d`.
 - `not_held_date_format`: The format for dates of meetings that were not held. Uses standard PHP date format (e.g., `Y/m`). Default: `Y/m`.
 - `class`: Adds a custom CSS class to the `<table>` element. Default: empty.
@@ -51,6 +54,7 @@ The plugin exposes a custom REST API endpoint for retrieving meeting minutes:
   - `page`: Page number for pagination.
   - `posts_per_page`: Number of posts per page.
   - `included_years`: Comma-separated list of years.
+  - `tags`: Comma-separated list of meeting tag slugs to filter by.
   - `held_date_format`: Date format for meetings that were held.
   - `not_held_date_format`: Date format for meetings that were not held.
 
@@ -58,6 +62,12 @@ The plugin exposes a custom REST API endpoint for retrieving meeting minutes:
 ```
 GET https://yourdomain.com/wp-json/edmm/v1/meeting-minutes/?included_years=2023&posts_per_page=10&page=1
 ```
+
+## Taxonomy
+
+The plugin registers a **Meeting Tags** taxonomy (`edmm_meeting_tag`) for the Meeting Minutes post type. Tags are non-hierarchical and can be managed from the Meeting Minutes admin screen. Use them to group or categorise meetings (e.g., "Board", "Annual", "Special Session").
+
+Tag slugs are used when filtering via the `tags` shortcode attribute or the `tags` REST API parameter.
 
 ## Meta Fields
 If the Advanced Custom Fields (ACF) plugin is active, the plugin adds the following fields to the Meeting Minutes custom post type:

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -247,9 +247,12 @@ function get_meeting_minutes( $request ) {
 				: '<span class="sr-text screen-reader-text">Notes not available</span>';
 
 			$tag_terms = get_the_terms( get_the_ID(), 'edmm_meeting_tag' );
-			$tag_names = ( $tag_terms && ! is_wp_error( $tag_terms ) )
-				? implode( ', ', wp_list_pluck( $tag_terms, 'name' ) )
-				: '';
+			$tags_data = array();
+			if ( $tag_terms && ! is_wp_error( $tag_terms ) ) {
+				foreach ( $tag_terms as $term ) {
+					$tags_data[] = array( 'name' => $term->name, 'slug' => $term->slug );
+				}
+			}
 
 			$meetings[] = array(
 				'title'  => get_the_title(),
@@ -258,7 +261,7 @@ function get_meeting_minutes( $request ) {
 					? 'Meeting not held'
 					: $agenda_item,
 				'notes'  => $notes_item,
-				'tags'   => $tag_names,
+				'tags'   => $tags_data,
 			);
 		}
 		wp_reset_postdata();
@@ -299,7 +302,6 @@ function meeting_minutes_shortcode( $atts ) {
     ), $atts, 'edmm_meeting_minutes' );
 
     $api_url = rest_url( 'edmm/v1/meeting-minutes/' ) . '?included_years=' . urlencode( $atts['included_years'] )
-        . '&tags=' . urlencode( $atts['tags'] )
         . '&held_date_format=' . urlencode( $atts['held_date_format'] )
         . '&not_held_date_format=' . urlencode( $atts['not_held_date_format'] )
         . '&posts_per_page=' . absint( $atts['posts_per_page'] );
@@ -316,6 +318,7 @@ function meeting_minutes_shortcode( $atts ) {
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             let currentPage = 1;
+            let activeTagFilter = '<?php echo esc_js( $atts['tags'] ); ?>';
             const apiUrl = '<?php echo esc_url_raw( $api_url ); ?>';
             const maxSlots = 7;
             const postsPerPage = <?php echo absint( $atts['posts_per_page'] ); ?>;
@@ -359,7 +362,14 @@ function meeting_minutes_shortcode( $atts ) {
                         table += '<td data-label="Notes">' + meeting.notes + '</td>';
                     }
                     if ('<?php echo esc_js( $atts['hide_tags'] ); ?>' !== 'true') {
-                        table += '<td data-label="<?php echo esc_js( $atts['tags_label'] ); ?>">' + (meeting.tags || '') + '</td>';
+                        let tagButtons = '';
+                        if (meeting.tags && meeting.tags.length) {
+                            meeting.tags.forEach(tag => {
+                                const isActive = activeTagFilter === tag.slug;
+                                tagButtons += '<button type="button" class="edmm-tag-filter' + (isActive ? ' active' : '') + '" data-slug="' + tag.slug + '" aria-pressed="' + isActive + '">' + tag.name + '</button>';
+                            });
+                        }
+                        table += '<td data-label="<?php echo esc_js( $atts['tags_label'] ); ?>">' + tagButtons + '</td>';
                     }
                     table += '</tr>';
                 });
@@ -418,6 +428,16 @@ function meeting_minutes_shortcode( $atts ) {
                     });
                 });
 
+                // Add tag filter click handlers
+                document.getElementById(uid + '-table').querySelectorAll('.edmm-tag-filter').forEach(button => {
+                    button.addEventListener('click', function() {
+                        const slug = this.getAttribute('data-slug');
+                        activeTagFilter = (activeTagFilter === slug) ? '' : slug;
+                        currentPage = 1;
+                        fetchMeetings();
+                    });
+                });
+
                 // Focus on the first link in the table
                 if (refocus) {
                     setTimeout(() => {
@@ -467,7 +487,10 @@ function meeting_minutes_shortcode( $atts ) {
             const fetchMeetings = (refocus) => {
                 refocus = refocus || false;
 
-                const urlWithPage = apiUrl + '&page=' + encodeURIComponent(currentPage);
+                let urlWithPage = apiUrl + '&page=' + encodeURIComponent(currentPage);
+                if (activeTagFilter) {
+                    urlWithPage += '&tags=' + encodeURIComponent(activeTagFilter);
+                }
                 fetch(urlWithPage)
                     .then(response => {
                         if (!response.ok) {
@@ -504,6 +527,22 @@ function meeting_minutes_shortcode( $atts ) {
         .edmm-pagination-button[disabled] {
             background-color: #ccc;
             cursor: not-allowed;
+        }
+
+        .edmm-tag-filter {
+            display: inline-block;
+            padding: 2px 8px;
+            margin: 2px;
+            border: 1px solid #007bff;
+            border-radius: 3px;
+            background-color: transparent;
+            color: #007bff;
+            cursor: pointer;
+            font-size: 0.875em;
+        }
+        .edmm-tag-filter.active {
+            background-color: #007bff;
+            color: white;
         }
 
         .edmm-meeting-minutes-table {

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -291,6 +291,7 @@ function meeting_minutes_shortcode( $atts ) {
         'hide_agenda'          => 'false',
         'hide_notes'           => 'false',
         'hide_tags'            => 'false',
+        'tags_label'           => 'Tags',
         'held_date_format'     => 'Y/m/d',
         'not_held_date_format' => 'Y/m',
         'class'                => '',
@@ -339,7 +340,7 @@ function meeting_minutes_shortcode( $atts ) {
                     table += '<th scope="col">Notes</th>';
                 }
                 if ('<?php echo esc_js( $atts['hide_tags'] ); ?>' !== 'true') {
-                    table += '<th scope="col">Tags</th>';
+                    table += '<th scope="col"><?php echo esc_js( $atts['tags_label'] ); ?></th>';
                 }
                 table += '</tr></thead><tbody>';
 
@@ -358,7 +359,7 @@ function meeting_minutes_shortcode( $atts ) {
                         table += '<td data-label="Notes">' + meeting.notes + '</td>';
                     }
                     if ('<?php echo esc_js( $atts['hide_tags'] ); ?>' !== 'true') {
-                        table += '<td data-label="Tags">' + (meeting.tags || '') + '</td>';
+                        table += '<td data-label="<?php echo esc_js( $atts['tags_label'] ); ?>">' + (meeting.tags || '') + '</td>';
                     }
                     table += '</tr>';
                 });

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -166,9 +166,10 @@ function get_meeting_minutes( $request ) {
     $page           = isset($params['page']) ? absint($params['page']) : 1;
     $posts_per_page = isset($params['posts_per_page']) ? absint($params['posts_per_page']) : 20;
 
-    $held_date_format = isset($params['held_date_format']) ? sanitize_text_field($params['held_date_format']) : 'Y/m/d';
+    $held_date_format     = isset($params['held_date_format']) ? sanitize_text_field($params['held_date_format']) : 'Y/m/d';
     $not_held_date_format = isset($params['not_held_date_format']) ? sanitize_text_field($params['not_held_date_format']) : 'Y/m';
-    $tags = isset($params['tags']) ? sanitize_text_field($params['tags']) : '';
+    $tags                 = isset($params['tags']) ? sanitize_text_field($params['tags']) : '';
+	$tags_filter          = isset($params['tags_filter']) ? sanitize_text_field($params['tags_filter']) : '';
 
     $args = array(
         'post_type'      => 'edmm_meeting_minutes',
@@ -206,14 +207,26 @@ function get_meeting_minutes( $request ) {
         $args['meta_query'][] = $year_queries;
     }
 
-    if ( ! empty( $tags ) ) {
-        $args['tax_query'] = array(
-            array(
-                'taxonomy' => 'edmm_meeting_tag',
-                'field'    => 'slug',
-                'terms'    => array_map( 'trim', explode( ',', $tags ) ),
-            ),
+    $tax_query = array( 'relation' => 'AND' );
+
+    if ( ! empty( $tags_filter ) ) {
+        $tax_query[] = array(
+            'taxonomy' => 'edmm_meeting_tag',
+            'field'    => 'slug',
+            'terms'    => array_map( 'trim', explode( ',', $tags_filter ) ),
         );
+    }
+
+    if ( ! empty( $tags ) ) {
+        $tax_query[] = array(
+            'taxonomy' => 'edmm_meeting_tag',
+            'field'    => 'slug',
+            'terms'    => array_map( 'trim', explode( ',', $tags ) ),
+        );
+    }
+
+    if ( count( $tax_query ) > 1 ) {
+        $args['tax_query'] = $tax_query;
     }
 
     $query = new \WP_Query( $args );
@@ -293,8 +306,9 @@ function meeting_minutes_shortcode( $atts ) {
         'hide_date'            => 'false',
         'hide_agenda'          => 'false',
         'hide_notes'           => 'false',
-        'hide_tags'            => 'false',
-        'tags_label'           => 'Tags',
+        'hide_tags'            => 'true',
+        'tags_label'           => 'Tags', // only used if hide_tags is false.
+		'tags_filter'          => '', // outputs items only with this tag slug.
         'held_date_format'     => 'Y/m/d',
         'not_held_date_format' => 'Y/m',
         'class'                => '',
@@ -304,7 +318,8 @@ function meeting_minutes_shortcode( $atts ) {
     $api_url = rest_url( 'edmm/v1/meeting-minutes/' ) . '?included_years=' . urlencode( $atts['included_years'] )
         . '&held_date_format=' . urlencode( $atts['held_date_format'] )
         . '&not_held_date_format=' . urlencode( $atts['not_held_date_format'] )
-        . '&posts_per_page=' . absint( $atts['posts_per_page'] );
+        . '&posts_per_page=' . absint( $atts['posts_per_page'] )
+        . ( ! empty( $atts['tags_filter'] ) ? '&tags_filter=' . urlencode( $atts['tags_filter'] ) : '' );
 
     static $instance = 0;
     $instance++;

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -43,6 +43,29 @@ function register_meeting_minutes_cpt() {
 add_action( 'init', __NAMESPACE__ . '\register_meeting_minutes_cpt' );
 
 /**
+ * Registers the 'Meeting Tag' taxonomy for the Meeting Minutes post type.
+ *
+ * @return void
+ */
+function register_meeting_minutes_taxonomy() {
+    $labels = array(
+        'name'          => _x( 'Meeting Tags', 'Taxonomy General Name', 'edmm' ),
+        'singular_name' => _x( 'Meeting Tag', 'Taxonomy Singular Name', 'edmm' ),
+        'menu_name'     => __( 'Meeting Tags', 'edmm' ),
+    );
+
+    register_taxonomy( 'edmm_meeting_tag', 'edmm_meeting_minutes', array(
+        'labels'       => $labels,
+        'hierarchical' => false,
+        'public'       => false,
+        'show_ui'      => true,
+        'show_in_rest' => true,
+        'rewrite'      => false,
+    ) );
+}
+add_action( 'init', __NAMESPACE__ . '\register_meeting_minutes_taxonomy' );
+
+/**
  * Adds ACF meta fields for the 'Meeting Minutes' post type.
  *
  * This function checks if the Advanced Custom Fields (ACF) plugin is active,
@@ -145,6 +168,7 @@ function get_meeting_minutes( $request ) {
 
     $held_date_format = isset($params['held_date_format']) ? sanitize_text_field($params['held_date_format']) : 'Y/m/d';
     $not_held_date_format = isset($params['not_held_date_format']) ? sanitize_text_field($params['not_held_date_format']) : 'Y/m';
+    $tags = isset($params['tags']) ? sanitize_text_field($params['tags']) : '';
 
     $args = array(
         'post_type'      => 'edmm_meeting_minutes',
@@ -182,6 +206,16 @@ function get_meeting_minutes( $request ) {
         $args['meta_query'][] = $year_queries;
     }
 
+    if ( ! empty( $tags ) ) {
+        $args['tax_query'] = array(
+            array(
+                'taxonomy' => 'edmm_meeting_tag',
+                'field'    => 'slug',
+                'terms'    => array_map( 'trim', explode( ',', $tags ) ),
+            ),
+        );
+    }
+
     $query = new \WP_Query( $args );
     $meetings = array();
 
@@ -212,6 +246,11 @@ function get_meeting_minutes( $request ) {
 				? apply_filters( 'edmm_meeting_notes_link', '<a href="' . $meeting_notes_url . '" aria-label="Notes for ' . $formatted_date . '">View Notes</a>' )
 				: '<span class="sr-text screen-reader-text">Notes not available</span>';
 
+			$tag_terms = get_the_terms( get_the_ID(), 'edmm_meeting_tag' );
+			$tag_names = ( $tag_terms && ! is_wp_error( $tag_terms ) )
+				? implode( ', ', wp_list_pluck( $tag_terms, 'name' ) )
+				: '';
+
 			$meetings[] = array(
 				'title'  => get_the_title(),
 				'date'   => $formatted_date,
@@ -219,6 +258,7 @@ function get_meeting_minutes( $request ) {
 					? 'Meeting not held'
 					: $agenda_item,
 				'notes'  => $notes_item,
+				'tags'   => $tag_names,
 			);
 		}
 		wp_reset_postdata();
@@ -245,10 +285,12 @@ function get_meeting_minutes( $request ) {
 function meeting_minutes_shortcode( $atts ) {
     $atts = shortcode_atts( array(
         'included_years'       => '',
+        'tags'                 => '',
         'hide_title'           => 'false',
         'hide_date'            => 'false',
         'hide_agenda'          => 'false',
         'hide_notes'           => 'false',
+        'hide_tags'            => 'false',
         'held_date_format'     => 'Y/m/d',
         'not_held_date_format' => 'Y/m',
         'class'                => '',
@@ -256,6 +298,7 @@ function meeting_minutes_shortcode( $atts ) {
     ), $atts, 'edmm_meeting_minutes' );
 
     $api_url = rest_url( 'edmm/v1/meeting-minutes/' ) . '?included_years=' . urlencode( $atts['included_years'] )
+        . '&tags=' . urlencode( $atts['tags'] )
         . '&held_date_format=' . urlencode( $atts['held_date_format'] )
         . '&not_held_date_format=' . urlencode( $atts['not_held_date_format'] )
         . '&posts_per_page=' . absint( $atts['posts_per_page'] );
@@ -295,6 +338,9 @@ function meeting_minutes_shortcode( $atts ) {
                 if ('<?php echo esc_js( $atts['hide_notes'] ); ?>' !== 'true') {
                     table += '<th scope="col">Notes</th>';
                 }
+                if ('<?php echo esc_js( $atts['hide_tags'] ); ?>' !== 'true') {
+                    table += '<th scope="col">Tags</th>';
+                }
                 table += '</tr></thead><tbody>';
 
                 data.meetings.forEach(meeting => {
@@ -310,6 +356,9 @@ function meeting_minutes_shortcode( $atts ) {
                     }
                     if ('<?php echo esc_js( $atts['hide_notes'] ); ?>' !== 'true') {
                         table += '<td data-label="Notes">' + meeting.notes + '</td>';
+                    }
+                    if ('<?php echo esc_js( $atts['hide_tags'] ); ?>' !== 'true') {
+                        table += '<td data-label="Tags">' + (meeting.tags || '') + '</td>';
                     }
                     table += '</tr>';
                 });

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -548,15 +548,15 @@ function meeting_minutes_shortcode( $atts ) {
             display: inline-block;
             padding: 2px 8px;
             margin: 2px;
-            border: 1px solid #007bff;
+            border: 1px solid #0056b3;
             border-radius: 3px;
             background-color: transparent;
-            color: #007bff;
+            color: #0056b3;
             cursor: pointer;
             font-size: 0.875em;
         }
         .edmm-category-filter.active {
-            background-color: #007bff;
+            background-color: #0056b3;
             color: white;
         }
 

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -43,20 +43,20 @@ function register_meeting_minutes_cpt() {
 add_action( 'init', __NAMESPACE__ . '\register_meeting_minutes_cpt' );
 
 /**
- * Registers the 'Meeting Tag' taxonomy for the Meeting Minutes post type.
+ * Registers the 'Meeting Category' taxonomy for the Meeting Minutes post type.
  *
  * @return void
  */
 function register_meeting_minutes_taxonomy() {
     $labels = array(
-        'name'          => _x( 'Meeting Tags', 'Taxonomy General Name', 'edmm' ),
-        'singular_name' => _x( 'Meeting Tag', 'Taxonomy Singular Name', 'edmm' ),
-        'menu_name'     => __( 'Meeting Tags', 'edmm' ),
+        'name'          => _x( 'Meeting Categories', 'Taxonomy General Name', 'edmm' ),
+        'singular_name' => _x( 'Meeting Category', 'Taxonomy Singular Name', 'edmm' ),
+        'menu_name'     => __( 'Meeting Categories', 'edmm' ),
     );
 
-    register_taxonomy( 'edmm_meeting_tag', 'edmm_meeting_minutes', array(
+    register_taxonomy( 'edmm_meeting_category', 'edmm_meeting_minutes', array(
         'labels'       => $labels,
-        'hierarchical' => false,
+        'hierarchical' => true,
         'public'       => false,
         'show_ui'      => true,
         'show_in_rest' => true,
@@ -169,7 +169,7 @@ function get_meeting_minutes( $request ) {
     $held_date_format     = isset($params['held_date_format']) ? sanitize_text_field($params['held_date_format']) : 'Y/m/d';
     $not_held_date_format = isset($params['not_held_date_format']) ? sanitize_text_field($params['not_held_date_format']) : 'Y/m';
     $tags                 = isset($params['tags']) ? sanitize_text_field($params['tags']) : '';
-	$tags_filter          = isset($params['tags_filter']) ? sanitize_text_field($params['tags_filter']) : '';
+	$category_filter          = isset($params['category_filter']) ? sanitize_text_field($params['category_filter']) : '';
 
     $args = array(
         'post_type'      => 'edmm_meeting_minutes',
@@ -209,17 +209,17 @@ function get_meeting_minutes( $request ) {
 
     $tax_query = array( 'relation' => 'AND' );
 
-    if ( ! empty( $tags_filter ) ) {
+    if ( ! empty( $category_filter ) ) {
         $tax_query[] = array(
-            'taxonomy' => 'edmm_meeting_tag',
+            'taxonomy' => 'edmm_meeting_category',
             'field'    => 'slug',
-            'terms'    => array_map( 'trim', explode( ',', $tags_filter ) ),
+            'terms'    => array_map( 'trim', explode( ',', $category_filter ) ),
         );
     }
 
     if ( ! empty( $tags ) ) {
         $tax_query[] = array(
-            'taxonomy' => 'edmm_meeting_tag',
+            'taxonomy' => 'edmm_meeting_category',
             'field'    => 'slug',
             'terms'    => array_map( 'trim', explode( ',', $tags ) ),
         );
@@ -259,22 +259,22 @@ function get_meeting_minutes( $request ) {
 				? apply_filters( 'edmm_meeting_notes_link', '<a href="' . $meeting_notes_url . '" aria-label="Notes for ' . $formatted_date . '">View Notes</a>' )
 				: '<span class="sr-text screen-reader-text">Notes not available</span>';
 
-			$tag_terms = get_the_terms( get_the_ID(), 'edmm_meeting_tag' );
-			$tags_data = array();
-			if ( $tag_terms && ! is_wp_error( $tag_terms ) ) {
-				foreach ( $tag_terms as $term ) {
-					$tags_data[] = array( 'name' => $term->name, 'slug' => $term->slug );
+			$category_terms = get_the_terms( get_the_ID(), 'edmm_meeting_category' );
+			$categories_data = array();
+			if ( $category_terms && ! is_wp_error( $category_terms ) ) {
+				foreach ( $category_terms as $term ) {
+					$categories_data[] = array( 'name' => $term->name, 'slug' => $term->slug, 'parent' => $term->parent );
 				}
 			}
 
 			$meetings[] = array(
-				'title'  => get_the_title(),
-				'date'   => $formatted_date,
-				'agenda' => $meeting_not_held
+				'title'      => get_the_title(),
+				'date'       => $formatted_date,
+				'agenda'     => $meeting_not_held
 					? 'Meeting not held'
 					: $agenda_item,
-				'notes'  => $notes_item,
-				'tags'   => $tags_data,
+				'notes'      => $notes_item,
+				'categories' => $categories_data,
 			);
 		}
 		wp_reset_postdata();
@@ -306,9 +306,9 @@ function meeting_minutes_shortcode( $atts ) {
         'hide_date'            => 'false',
         'hide_agenda'          => 'false',
         'hide_notes'           => 'false',
-        'hide_tags'            => 'true',
-        'tags_label'           => 'Tags', // only used if hide_tags is false.
-		'tags_filter'          => '', // outputs items only with this tag slug.
+        'hide_categories'      => 'true',
+        'categories_label'     => 'Categories', // only used if hide_categories is false.
+		'category_filter'      => '', // outputs items only with this category slug.
         'held_date_format'     => 'Y/m/d',
         'not_held_date_format' => 'Y/m',
         'class'                => '',
@@ -319,7 +319,7 @@ function meeting_minutes_shortcode( $atts ) {
         . '&held_date_format=' . urlencode( $atts['held_date_format'] )
         . '&not_held_date_format=' . urlencode( $atts['not_held_date_format'] )
         . '&posts_per_page=' . absint( $atts['posts_per_page'] )
-        . ( ! empty( $atts['tags_filter'] ) ? '&tags_filter=' . urlencode( $atts['tags_filter'] ) : '' );
+        . ( ! empty( $atts['category_filter'] ) ? '&category_filter=' . urlencode( $atts['category_filter'] ) : '' );
 
     static $instance = 0;
     $instance++;
@@ -333,7 +333,7 @@ function meeting_minutes_shortcode( $atts ) {
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             let currentPage = 1;
-            let activeTagFilter = '<?php echo esc_js( $atts['tags'] ); ?>';
+            let activeCategoryFilter = '<?php echo esc_js( $atts['tags'] ); ?>';
             const apiUrl = '<?php echo esc_url_raw( $api_url ); ?>';
             const maxSlots = 7;
             const postsPerPage = <?php echo absint( $atts['posts_per_page'] ); ?>;
@@ -357,8 +357,8 @@ function meeting_minutes_shortcode( $atts ) {
                 if ('<?php echo esc_js( $atts['hide_notes'] ); ?>' !== 'true') {
                     table += '<th scope="col">Notes</th>';
                 }
-                if ('<?php echo esc_js( $atts['hide_tags'] ); ?>' !== 'true') {
-                    table += '<th scope="col"><?php echo esc_js( $atts['tags_label'] ); ?></th>';
+                if ('<?php echo esc_js( $atts['hide_categories'] ); ?>' !== 'true') {
+                    table += '<th scope="col"><?php echo esc_js( $atts['categories_label'] ); ?></th>';
                 }
                 table += '</tr></thead><tbody>';
 
@@ -376,15 +376,15 @@ function meeting_minutes_shortcode( $atts ) {
                     if ('<?php echo esc_js( $atts['hide_notes'] ); ?>' !== 'true') {
                         table += '<td data-label="Notes">' + meeting.notes + '</td>';
                     }
-                    if ('<?php echo esc_js( $atts['hide_tags'] ); ?>' !== 'true') {
-                        let tagButtons = '';
-                        if (meeting.tags && meeting.tags.length) {
-                            meeting.tags.forEach(tag => {
-                                const isActive = activeTagFilter === tag.slug;
-                                tagButtons += '<button type="button" class="edmm-tag-filter' + (isActive ? ' active' : '') + '" data-slug="' + tag.slug + '" aria-pressed="' + isActive + '">' + tag.name + '</button>';
+                    if ('<?php echo esc_js( $atts['hide_categories'] ); ?>' !== 'true') {
+                        let categoryButtons = '';
+                        if (meeting.categories && meeting.categories.length) {
+                            meeting.categories.forEach(category => {
+                                const isActive = activeCategoryFilter === category.slug;
+                                categoryButtons += '<button type="button" class="edmm-category-filter' + (isActive ? ' active' : '') + '" data-slug="' + category.slug + '" aria-pressed="' + isActive + '">' + category.name + '</button>';
                             });
                         }
-                        table += '<td data-label="<?php echo esc_js( $atts['tags_label'] ); ?>">' + tagButtons + '</td>';
+                        table += '<td data-label="<?php echo esc_js( $atts['categories_label'] ); ?>">' + categoryButtons + '</td>';
                     }
                     table += '</tr>';
                 });
@@ -443,11 +443,11 @@ function meeting_minutes_shortcode( $atts ) {
                     });
                 });
 
-                // Add tag filter click handlers
-                document.getElementById(uid + '-table').querySelectorAll('.edmm-tag-filter').forEach(button => {
+                // Add category filter click handlers
+                document.getElementById(uid + '-table').querySelectorAll('.edmm-category-filter').forEach(button => {
                     button.addEventListener('click', function() {
                         const slug = this.getAttribute('data-slug');
-                        activeTagFilter = (activeTagFilter === slug) ? '' : slug;
+                        activeCategoryFilter = (activeCategoryFilter === slug) ? '' : slug;
                         currentPage = 1;
                         fetchMeetings();
                     });
@@ -503,8 +503,8 @@ function meeting_minutes_shortcode( $atts ) {
                 refocus = refocus || false;
 
                 let urlWithPage = apiUrl + '&page=' + encodeURIComponent(currentPage);
-                if (activeTagFilter) {
-                    urlWithPage += '&tags=' + encodeURIComponent(activeTagFilter);
+                if (activeCategoryFilter) {
+                    urlWithPage += '&tags=' + encodeURIComponent(activeCategoryFilter);
                 }
                 fetch(urlWithPage)
                     .then(response => {
@@ -544,7 +544,7 @@ function meeting_minutes_shortcode( $atts ) {
             cursor: not-allowed;
         }
 
-        .edmm-tag-filter {
+        .edmm-category-filter {
             display: inline-block;
             padding: 2px 8px;
             margin: 2px;
@@ -555,7 +555,7 @@ function meeting_minutes_shortcode( $atts ) {
             cursor: pointer;
             font-size: 0.875em;
         }
-        .edmm-tag-filter.active {
+        .edmm-category-filter.active {
             background-color: #007bff;
             color: white;
         }

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -260,17 +260,22 @@ function meeting_minutes_shortcode( $atts ) {
         . '&not_held_date_format=' . urlencode( $atts['not_held_date_format'] )
         . '&posts_per_page=' . absint( $atts['posts_per_page'] );
 
+    static $instance = 0;
+    $instance++;
+    $uid = 'edmm-instance-' . $instance;
+
     ob_start();
     ?>
-    <div id="edmm-meeting-minutes-table"></div>
-    <div id="edmm-pagination"></div>
-    <div id="pagination-info" aria-live="polite" aria-atomic="true" style="position: absolute; left: -9999px;"></div>
+    <div id="<?php echo esc_attr( $uid ); ?>-table" class="edmm-meeting-minutes-table-wrapper"></div>
+    <div id="<?php echo esc_attr( $uid ); ?>-pagination" class="edmm-pagination"></div>
+    <div id="<?php echo esc_attr( $uid ); ?>-info" class="edmm-pagination-info" aria-live="polite" aria-atomic="true" style="position: absolute; left: -9999px;"></div>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             let currentPage = 1;
             const apiUrl = '<?php echo esc_url_raw( $api_url ); ?>';
             const maxSlots = 7;
             const postsPerPage = <?php echo absint( $atts['posts_per_page'] ); ?>;
+            const uid = '<?php echo esc_js( $uid ); ?>';
 
             const renderTable = (data, refocus = false) => {
                 refocus = refocus || false;
@@ -310,14 +315,14 @@ function meeting_minutes_shortcode( $atts ) {
                 });
                 table += '</tbody></table>';
 
-                document.getElementById('edmm-meeting-minutes-table').innerHTML = table;
+                document.getElementById(uid + '-table').innerHTML = table;
 
                 // Update aria-live region with pagination info
                 const totalEntries = data.total_entries;
                 const startEntry = (currentPage - 1) * postsPerPage + 1;
                 const endEntry = Math.min(currentPage * postsPerPage, totalEntries);
                 const paginationInfo = `Showing ${startEntry} to ${endEntry} of ${totalEntries} entries`;
-                document.getElementById('pagination-info').textContent = paginationInfo;
+                document.getElementById(uid + '-info').textContent = paginationInfo;
 
                 // Pagination HTML
                 let pagination = '';
@@ -349,10 +354,10 @@ function meeting_minutes_shortcode( $atts ) {
                     pagination += '</div></nav>';
                 }
 
-                document.getElementById('edmm-pagination').innerHTML = pagination;
+                document.getElementById(uid + '-pagination').innerHTML = pagination;
 
                 // Add event listeners to buttons
-                document.querySelectorAll('#edmm-pagination button').forEach(button => {
+                document.getElementById(uid + '-pagination').querySelectorAll('button').forEach(button => {
                     button.addEventListener('click', function(e) {
                         e.preventDefault();
                         const targetPage = parseInt(this.getAttribute('data-page'));
@@ -366,7 +371,7 @@ function meeting_minutes_shortcode( $atts ) {
                 // Focus on the first link in the table
                 if (refocus) {
                     setTimeout(() => {
-                        document.querySelector('.edmm-meeting-minutes-table')?.focus();
+                        document.getElementById(uid + '-table').querySelector('.edmm-meeting-minutes-table')?.focus();
                     }, 100);
                 }
 

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -169,7 +169,7 @@ function get_meeting_minutes( $request ) {
     $held_date_format     = isset($params['held_date_format']) ? sanitize_text_field($params['held_date_format']) : 'Y/m/d';
     $not_held_date_format = isset($params['not_held_date_format']) ? sanitize_text_field($params['not_held_date_format']) : 'Y/m';
     $tags                 = isset($params['tags']) ? sanitize_text_field($params['tags']) : '';
-	$category_filter          = isset($params['category_filter']) ? sanitize_text_field($params['category_filter']) : '';
+	$category_filter      = isset($params['category_filter']) ? sanitize_text_field($params['category_filter']) : '';
 
     $args = array(
         'post_type'      => 'edmm_meeting_minutes',
@@ -333,7 +333,7 @@ function meeting_minutes_shortcode( $atts ) {
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             let currentPage = 1;
-            let activeCategoryFilter = '<?php echo esc_js( $atts['tags'] ); ?>';
+            let activeCategoryFilter = '<?php echo esc_js( $atts['category_filter'] ); ?>';
             const apiUrl = '<?php echo esc_url_raw( $api_url ); ?>';
             const maxSlots = 7;
             const postsPerPage = <?php echo absint( $atts['posts_per_page'] ); ?>;
@@ -504,7 +504,7 @@ function meeting_minutes_shortcode( $atts ) {
 
                 let urlWithPage = apiUrl + '&page=' + encodeURIComponent(currentPage);
                 if (activeCategoryFilter) {
-                    urlWithPage += '&tags=' + encodeURIComponent(activeCategoryFilter);
+                    urlWithPage += '&category_filter=' + encodeURIComponent(activeCategoryFilter);
                 }
                 fetch(urlWithPage)
                     .then(response => {


### PR DESCRIPTION
Adds tags to the meeting minutes cpt, adds some tag filtering capabilities to the shortcode as well as having optional output of said tags (also with clickable filters).

Additionally it was made to be able to have multiple on a page at once. Details about that breaking change is below:

Previously, the [edmm_meeting_minutes] shortcode used hard-coded element IDs (edmm-meeting-minutes-table, edmm-pagination, pagination-info), meaning only the first instance on a page would render correctly. Additional instances would silently update the first instance's DOM instead of their own.                                                                                
                                                                                                     
This change generates a unique ID per shortcode instance (e.g., edmm-instance-1-table) and scopes all JavaScript DOM queries to that instance.
                                                                                                       
**Possible breaking changes**                                                                            
   
The following IDs no longer exist in the rendered HTML and any CSS or JavaScript targeting them will stop working:                                                                                      
                                                                                                       
  - #edmm-meeting-minutes-table                                                                        
  - #edmm-pagination
  - #pagination-info                                                                                   
                                                                                                     
These have been replaced with classes of the same names so CSS can be migrated easily:               
   
  - .edmm-meeting-minutes-table-wrapper                                                                
  - .edmm-pagination                                                                                 
  - .edmm-pagination-info                                                                              
                                                                                                       
Anywhere that was styling this by the ids will need to be updated for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-meeting categories and tags; both are included on meeting records and filterable via API parameters.
  * Optional categories column, tag/category filter controls (buttons), and per-instance UID-scoped UI with keyboard-friendly interactions.

* **Bug Fixes**
  * Multiple shortcode instances run independently without ID collisions.
  * Pagination and filtering respect per-instance state and propagate filters through the API.

* **Documentation**
  * Updated docs for tags, categories, shortcode attributes, and REST filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->