### PR TITLE
Fix security audit findings: stored XSS and authorization gaps

### DIFF
--- a/assets/js/meeting-minutes.js
+++ b/assets/js/meeting-minutes.js
@@ -2,6 +2,8 @@
 // before DOMContentLoaded so they are included in the initial render.
 //
 // Each entry: { key: string, label: string, renderCell: function(meeting) → string }
+// renderCell()'s return value is inserted directly as HTML - it must escape
+// any untrusted data itself before returning.
 window.edmmExtraColumns = window.edmmExtraColumns || [];
 
 ( function() {
@@ -103,6 +105,12 @@ window.edmmExtraColumns = window.edmmExtraColumns || [];
 
 			table += '</tr></thead><tbody>';
 
+			// Cell content below (meeting.title, meeting.date, meeting.agenda,
+			// meeting.minutes, and any Pro-registered renderCell() output) is
+			// inserted as trusted, pre-escaped HTML by contract - the REST
+			// endpoint escapes title/date server-side, and agenda/minutes are
+			// pre-built escaped <a> markup. Any new field or extra-column
+			// renderCell() must escape its own output before returning it here.
 			data.meetings.forEach( function( meeting ) {
 				table += '<tr>';
 				if ( ! instanceCfg.hideTitle ) {

--- a/assets/js/meeting-minutes.js
+++ b/assets/js/meeting-minutes.js
@@ -2,7 +2,8 @@
 // before DOMContentLoaded so they are included in the initial render.
 //
 // Each entry: { key: string, label: string, renderCell: function(meeting) → string }
-// renderCell()'s return value is inserted directly as HTML - it must escape
+// renderCell()'s return value, and label/getLabel()'s return value (used as
+// raw column header HTML), are inserted directly as HTML - each must escape
 // any untrusted data itself before returning.
 window.edmmExtraColumns = window.edmmExtraColumns || [];
 

--- a/src/Admin/MetaBox.php
+++ b/src/Admin/MetaBox.php
@@ -96,7 +96,12 @@ JS;
 		$common = [
 			'single'        => true,
 			'show_in_rest'  => true,
-			'auth_callback' => fn( $allowed, $meta_key, $object_id ) => current_user_can( 'edit_post', $object_id ),
+			// $object_id is 0 when the REST API is authorizing meta for a post
+			// that doesn't exist yet (e.g. new-post autosave), so fall back to
+			// the general capability check in that case.
+			'auth_callback' => fn( $allowed, $meta_key, $object_id ) => $object_id
+				? current_user_can( 'edit_post', $object_id )
+				: current_user_can( 'edit_posts' ),
 		];
 
 		register_post_meta(

--- a/src/Admin/MetaBox.php
+++ b/src/Admin/MetaBox.php
@@ -96,7 +96,7 @@ JS;
 		$common = [
 			'single'        => true,
 			'show_in_rest'  => true,
-			'auth_callback' => fn() => current_user_can( 'edit_posts' ),
+			'auth_callback' => fn( $allowed, $meta_key, $object_id ) => current_user_can( 'edit_post', $object_id ),
 		];
 
 		register_post_meta(

--- a/src/PostType/MeetingMinutes.php
+++ b/src/PostType/MeetingMinutes.php
@@ -38,10 +38,15 @@ class MeetingMinutes {
 			'label'         => __( 'Meeting Minute', 'edmm' ),
 			'labels'        => $labels,
 			'supports'      => [ 'title' ],
+			// No public single/archive templates — meeting minutes are only ever
+			// displayed via the [edmm_meeting_minutes] shortcode's own REST endpoint.
 			'public'        => false,
 			'rewrite'       => false,
 			'has_archive'   => false,
 			'show_ui'       => true,
+			// Intentionally still exposes the default /wp/v2/edmm_meeting_minutes
+			// REST route (needed for the block editor meta box UI); this is fine
+			// since published meeting minutes are meant to be public records.
 			'show_in_rest'  => true,
 			'menu_position' => 5,
 			'menu_icon'     => 'dashicons-calendar',

--- a/src/REST/MeetingMinutesEndpoint.php
+++ b/src/REST/MeetingMinutesEndpoint.php
@@ -50,12 +50,12 @@ class MeetingMinutesEndpoint {
 					'held_date_format'     => [
 						'default'           => 'Y/m/d',
 						'sanitize_callback' => 'sanitize_text_field',
-						'validate_callback' => [ $this, 'validate_date_format' ],
+						'validate_callback' => [ __CLASS__, 'validate_date_format' ],
 					],
 					'not_held_date_format' => [
 						'default'           => 'Y/m',
 						'sanitize_callback' => 'sanitize_text_field',
-						'validate_callback' => [ $this, 'validate_date_format' ],
+						'validate_callback' => [ __CLASS__, 'validate_date_format' ],
 					],
 					'included_years'       => [
 						'default'           => '',
@@ -237,7 +237,7 @@ class MeetingMinutesEndpoint {
 	 * @param string $value The raw held_date_format/not_held_date_format value.
 	 * @return bool
 	 */
-	public function validate_date_format( string $value ): bool {
+	public static function validate_date_format( string $value ): bool {
 		return (bool) preg_match( '/^[A-Za-z0-9\/\-.: ,]*$/', $value );
 	}
 

--- a/src/REST/MeetingMinutesEndpoint.php
+++ b/src/REST/MeetingMinutesEndpoint.php
@@ -232,13 +232,22 @@ class MeetingMinutesEndpoint {
 	 *
 	 * Rejects backslashes so a caller cannot force otherwise-reserved
 	 * format characters to be output as literal text via DateTime's
-	 * escape syntax.
+	 * escape syntax. Also caps the length to avoid feeding pathologically
+	 * long strings into DateTime::format() once per result row.
 	 *
-	 * @param string $value The raw held_date_format/not_held_date_format value.
+	 * No type hint on $value: REST validate_callbacks can receive
+	 * non-string raw request values (e.g. an array from a repeated query
+	 * param), and a strict type hint would throw a TypeError instead of
+	 * just failing validation.
+	 *
+	 * @param mixed $value The raw held_date_format/not_held_date_format value.
 	 * @return bool
 	 */
-	public static function validate_date_format( string $value ): bool {
-		return (bool) preg_match( '/^[A-Za-z0-9\/\-.: ,]*$/', $value );
+	public static function validate_date_format( $value ): bool {
+		if ( ! is_string( $value ) ) {
+			return false;
+		}
+		return strlen( $value ) <= 32 && (bool) preg_match( '/^[A-Za-z0-9\/\-.: ,]*$/', $value );
 	}
 
 	/**

--- a/src/REST/MeetingMinutesEndpoint.php
+++ b/src/REST/MeetingMinutesEndpoint.php
@@ -50,10 +50,12 @@ class MeetingMinutesEndpoint {
 					'held_date_format'     => [
 						'default'           => 'Y/m/d',
 						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ $this, 'validate_date_format' ],
 					],
 					'not_held_date_format' => [
 						'default'           => 'Y/m',
 						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ $this, 'validate_date_format' ],
 					],
 					'included_years'       => [
 						'default'           => '',
@@ -154,7 +156,7 @@ class MeetingMinutesEndpoint {
 
 				$date_object    = $this->parse_date( $meeting_date );
 				$formatted_date = $date_object
-					? $date_object->format( $meeting_not_held ? $not_held_date_format : $held_date_format )
+					? esc_html( $date_object->format( $meeting_not_held ? $not_held_date_format : $held_date_format ) )
 					: '<span class="sr-text screen-reader-text">' . esc_html__( 'Date not available', 'edmm' ) . '</span>';
 
 				$agenda_item = $meeting_agenda_url
@@ -186,7 +188,7 @@ class MeetingMinutesEndpoint {
 					: '<span class="sr-text screen-reader-text">' . esc_html__( 'Minutes not available', 'edmm' ) . '</span>';
 
 				$row = [
-					'title'   => get_the_title(),
+					'title'   => esc_html( get_the_title() ),
 					'date'    => $formatted_date,
 					'agenda'  => $meeting_not_held ? esc_html__( 'Meeting not held', 'edmm' ) : $agenda_item,
 					'minutes' => $minutes_item,
@@ -222,6 +224,21 @@ class MeetingMinutesEndpoint {
 		$response = apply_filters( 'edmm_rest_response', $response, $request );
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Validates that a date format string only contains recognized PHP
+	 * date() format characters and safe literal separators.
+	 *
+	 * Rejects backslashes so a caller cannot force otherwise-reserved
+	 * format characters to be output as literal text via DateTime's
+	 * escape syntax.
+	 *
+	 * @param string $value The raw held_date_format/not_held_date_format value.
+	 * @return bool
+	 */
+	public function validate_date_format( string $value ): bool {
+		return (bool) preg_match( '/^[A-Za-z0-9\/\-.: ,]*$/', $value );
 	}
 
 	/**

--- a/src/Shortcode/MeetingMinutesShortcode.php
+++ b/src/Shortcode/MeetingMinutesShortcode.php
@@ -7,6 +7,8 @@
 
 namespace EqualizeDigital\MeetingMinutes\Shortcode;
 
+use EqualizeDigital\MeetingMinutes\REST\MeetingMinutesEndpoint;
+
 /**
  * Registers the [edmm_meeting_minutes] shortcode and manages
  * conditional asset enqueuing.
@@ -176,8 +178,8 @@ class MeetingMinutesShortcode {
 			'agendaLinkLabel'   => sanitize_text_field( $atts['agenda_link_label'] ),
 			'minutesLinkLabel'  => sanitize_text_field( $atts['minutes_link_label'] ),
 			'category'          => sanitize_text_field( $atts['category'] ?? '' ),
-			'heldDateFormat'    => sanitize_text_field( $atts['held_date_format'] ),
-			'notHeldDateFormat' => sanitize_text_field( $atts['not_held_date_format'] ),
+			'heldDateFormat'    => $this->sanitize_date_format( $atts['held_date_format'], $defaults['held_date_format'] ),
+			'notHeldDateFormat' => $this->sanitize_date_format( $atts['not_held_date_format'], $defaults['not_held_date_format'] ),
 			'tableClass'        => $this->sanitize_class_list( $atts['class'] ),
 			'postsPerPage'      => absint( $atts['posts_per_page'] ),
 		];
@@ -226,5 +228,23 @@ class MeetingMinutesShortcode {
 	private function sanitize_class_list( string $class_list ): string {
 		$classes = array_map( 'sanitize_html_class', explode( ' ', $class_list ) );
 		return implode( ' ', array_filter( $classes ) );
+	}
+
+	/**
+	 * Sanitizes a date format shortcode attribute and falls back to the
+	 * given default if it fails the same allow-list the REST endpoint
+	 * enforces (MeetingMinutesEndpoint::validate_date_format()).
+	 *
+	 * Without this, an invalid shortcode attribute would still reach the
+	 * REST fetch, get rejected with a 400, and silently fail to render
+	 * the whole table client-side.
+	 *
+	 * @param string $value   Raw held_date_format/not_held_date_format attribute.
+	 * @param string $default_value Fallback value if $value is invalid.
+	 * @return string
+	 */
+	private function sanitize_date_format( string $value, string $default_value ): string {
+		$value = sanitize_text_field( $value );
+		return MeetingMinutesEndpoint::validate_date_format( $value ) ? $value : $default_value;
 	}
 }

--- a/src/Shortcode/MeetingMinutesShortcode.php
+++ b/src/Shortcode/MeetingMinutesShortcode.php
@@ -176,8 +176,8 @@ class MeetingMinutesShortcode {
 			'agendaLinkLabel'   => sanitize_text_field( $atts['agenda_link_label'] ),
 			'minutesLinkLabel'  => sanitize_text_field( $atts['minutes_link_label'] ),
 			'category'          => sanitize_text_field( $atts['category'] ?? '' ),
-			'heldDateFormat'    => $atts['held_date_format'],
-			'notHeldDateFormat' => $atts['not_held_date_format'],
+			'heldDateFormat'    => sanitize_text_field( $atts['held_date_format'] ),
+			'notHeldDateFormat' => sanitize_text_field( $atts['not_held_date_format'] ),
 			'tableClass'        => $this->sanitize_class_list( $atts['class'] ),
 			'postsPerPage'      => absint( $atts['posts_per_page'] ),
 		];


### PR DESCRIPTION
## Summary
Fixes all findings from a full-plugin logic/escaping/sanitization audit (independently verified by a second review pass before implementation).

**HIGH — confirmed exploitable**
- Stored XSS via post title: `MeetingMinutesEndpoint::get_meeting_minutes()` returned `get_the_title()` unescaped in the public JSON response (`permission_callback: __return_true`), and the client renders `meeting.title` via `innerHTML`. Editors have `unfiltered_html` by default on non-multisite WordPress and can publish this CPT, so an Editor-level user (not just Admin) could store a `<script>` tag that executes for every anonymous site visitor. Fixed with `esc_html( get_the_title() )` at the source.

**Downgraded on verification, fixed as defense-in-depth anyway**
- The originally-flagged "reflected XSS via `held_date_format`" turned out not to be practically exploitable — `sanitize_text_field()`'s `strip_tags()` call structurally prevents a `<`/`>` pair from ever surviving to reach `DateTime::format()`, even via the backslash-escape trick. Still added an explicit `validate_callback` allow-listing safe characters (rejecting backslash) so this isn't relying on an incidental side effect of a different sanitizer, and escaped the formatted date at the source too.

**MEDIUM**
- `MetaBox::register_post_meta`'s `auth_callback` used a blanket `current_user_can( 'edit_posts' )` instead of checking the specific post (`current_user_can( 'edit_post', $object_id )`). The default REST controller already independently re-checks post-specific edit rights before any meta write, so this wasn't independently exploitable today, but it's tightened as defense-in-depth for any future code path.
- Documented the `renderCell()`-must-escape-its-own-output contract for Pro's extra-columns JS API (not attacker-reachable through the free plugin alone, since it never populates that registry itself).

**LOW — consistency fixes**
- Shortcode-level `held_date_format`/`not_held_date_format` attributes now run through `sanitize_text_field()` like their sibling attributes (previously the only two that didn't; already re-sanitized at the REST layer regardless).
- Documented the intentional `public => false` + `show_in_rest => true` CPT config (exposes the default `/wp/v2/edmm_meeting_minutes` route alongside the custom endpoint; low impact since the underlying data is meant to be public).

## Test plan
- [x] `composer lint` (php-parallel-lint) passes
- [x] `composer check-cs -- --report-full --ignore=vendor` passes
- [x] `npx wp-scripts lint-js assets/js/meeting-minutes.js` passes
- [x] Verified the date-format validator: `Y/m/d` and `Y-m-d H:i:s` pass, `<script>` and backslash-escaped sequences are rejected
- [x] Confirmed the date fallback ("Date not available" screen-reader span) still renders correctly and isn't double-escaped by the new `esc_html()` call (only the successful `DateTime::format()` branch is escaped; the fallback HTML span is untouched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened permission checks for editing meeting-minute metadata in the block editor and REST workflows.
  * Validated `held_date_format` and `not_held_date_format` inputs in the meeting minutes API.
  * Escaped formatted meeting dates and meeting titles returned by the API to improve output safety.
  * Sanitized and validated shortcode date-format settings, falling back to defaults on invalid values.
* **Documentation**
  * Updated guidance on how extra meeting-table content is rendered to clarify escaping expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->