### PR TITLE
Add Pro-plugin extension points: filterable CPT/REST args, reusable row builder, table hooks

### DIFF
--- a/docs/HOOK-CONTRACT-CHANGES.md
+++ b/docs/HOOK-CONTRACT-CHANGES.md
@@ -1,0 +1,28 @@
+# Hook Contract Changes
+
+Tracks changes to existing hook/filter *call signatures* (not just new hooks) that the Pro plugin must account for. The free and Pro plugins are developed in separate repos, so there's no compiler to catch a Pro callback written against an old contract — check this doc against Pro's hook usage before every Pro release.
+
+Newly *added* hooks (no compatibility concern, just new capability) are tracked in `CLAUDE.md`'s extension-point table instead of here.
+
+---
+
+## PR #9 — `edmm_meeting_row_data`'s `$request` argument can now be `null`
+
+**Before:** `edmm_meeting_row_data` was only ever fired from inside `MeetingMinutesEndpoint::get_meeting_minutes()`, so the third argument (`$request`) was always a real `\WP_REST_Request` instance.
+
+**After:** The per-row building logic was extracted into a new public method, `MeetingMinutesEndpoint::build_meeting_row( int $post_id, array $format_args, ?\WP_REST_Request $request = null ): array`, specifically so Pro features that need the same escaped/formatted row data *outside* a REST request (CSV/PDF export, an iCal feed, a "most recent meeting" widget) can call it directly. When called this way, `$request` will be `null`.
+
+**Contract impact:** Any callback hooked to `edmm_meeting_row_data` that type-hints its third parameter as `\WP_REST_Request` (rather than `?\WP_REST_Request` or leaving it untyped) will throw a fatal `TypeError` the first time something calls `build_meeting_row()` outside the REST endpoint.
+
+```php
+// Before this change, safe:
+add_filter( 'edmm_meeting_row_data', function ( array $row, int $post_id, \WP_REST_Request $request ) { ... }, 10, 3 );
+
+// Now required for compatibility:
+add_filter( 'edmm_meeting_row_data', function ( array $row, int $post_id, ?\WP_REST_Request $request ) { ... }, 10, 3 );
+// or simply omit/relax the type hint and null-check before use.
+```
+
+**Action for Pro before release:** grep Pro's codebase for `edmm_meeting_row_data` and confirm every callback either doesn't type-hint the third parameter, type-hints it nullable, or defensively checks `$request` before calling any `\WP_REST_Request` method on it.
+
+*(Flagged during review of PR #9 by Gemini Code Assist — as of that PR, `build_meeting_row()` passes `$request` through as `null` when the caller doesn't supply one, rather than substituting a dummy `\WP_REST_Request` instance. If that gets changed to always pass a real instance instead, update this doc.)*

--- a/src/PostType/MeetingMinutes.php
+++ b/src/PostType/MeetingMinutes.php
@@ -53,6 +53,17 @@ class MeetingMinutes {
 		];
 
 		/**
+		 * Filters the edmm_meeting_minutes CPT registration args.
+		 *
+		 * Pro plugin uses this to enable public/rewrite/archive support (e.g.
+		 * for an auto-generated archive page or RSS feed) or to change
+		 * capability_type for a custom approval-workflow capability set.
+		 *
+		 * @param array $args The register_post_type() args.
+		 */
+		$args = apply_filters( 'edmm_cpt_args', $args );
+
+		/**
 		 * Fires before the Meeting Minutes CPT is registered.
 		 * Use this hook to register taxonomies that need to bind to the CPT.
 		 */

--- a/src/REST/MeetingMinutesEndpoint.php
+++ b/src/REST/MeetingMinutesEndpoint.php
@@ -31,6 +31,55 @@ class MeetingMinutesEndpoint {
 	 * @return void
 	 */
 	public function register_route(): void {
+		$args = [
+			'page'                 => [
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+			],
+			'posts_per_page'       => [
+				'default'           => 20,
+				'sanitize_callback' => 'absint',
+			],
+			'held_date_format'     => [
+				'default'           => 'Y/m/d',
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => [ __CLASS__, 'validate_date_format' ],
+			],
+			'not_held_date_format' => [
+				'default'           => 'Y/m',
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => [ __CLASS__, 'validate_date_format' ],
+			],
+			'included_years'       => [
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'category'             => [
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'agenda_link_label'    => [
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'minutes_link_label'   => [
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+		];
+
+		/**
+		 * Filters the registered args schema for the meeting-minutes REST
+		 * route before it's registered.
+		 *
+		 * Pro plugin uses this to add new params (e.g. full-text search,
+		 * a date range) to this same route, rather than standing up a
+		 * separate route that would need to duplicate the query logic.
+		 *
+		 * @param array $args The REST route args schema.
+		 */
+		$args = apply_filters( 'edmm_rest_route_args', $args );
+
 		register_rest_route(
 			'edmm/v1',
 			'/meeting-minutes/',
@@ -38,42 +87,7 @@ class MeetingMinutesEndpoint {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_meeting_minutes' ],
 				'permission_callback' => '__return_true', // Public data — meeting minutes are public records.
-				'args'                => [
-					'page'                 => [
-						'default'           => 1,
-						'sanitize_callback' => 'absint',
-					],
-					'posts_per_page'       => [
-						'default'           => 20,
-						'sanitize_callback' => 'absint',
-					],
-					'held_date_format'     => [
-						'default'           => 'Y/m/d',
-						'sanitize_callback' => 'sanitize_text_field',
-						'validate_callback' => [ __CLASS__, 'validate_date_format' ],
-					],
-					'not_held_date_format' => [
-						'default'           => 'Y/m',
-						'sanitize_callback' => 'sanitize_text_field',
-						'validate_callback' => [ __CLASS__, 'validate_date_format' ],
-					],
-					'included_years'       => [
-						'default'           => '',
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'category'             => [
-						'default'           => '',
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'agenda_link_label'    => [
-						'default'           => '',
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'minutes_link_label'   => [
-						'default'           => '',
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-				],
+				'args'                => $args,
 			]
 		);
 	}
@@ -142,67 +156,17 @@ class MeetingMinutesEndpoint {
 		if ( $query->have_posts() ) {
 			while ( $query->have_posts() ) {
 				$query->the_post();
-				$post_id = get_the_ID();
 
-				$meeting_date        = get_post_meta( $post_id, 'edmm_meeting_date', true );
-				$meeting_not_held    = (bool) get_post_meta( $post_id, 'edmm_meeting_not_held', true );
-				$meeting_agenda_url  = get_post_meta( $post_id, 'edmm_meeting_agenda_url', true );
-				$meeting_minutes_url = get_post_meta( $post_id, 'edmm_meeting_minutes_url', true );
-
-				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- intentional, gated behind WP_DEBUG for troubleshooting date parsing.
-					error_log( 'EDMM: Raw meeting date for post ' . $post_id . ': ' . $meeting_date );
-				}
-
-				$date_object    = $this->parse_date( $meeting_date );
-				$formatted_date = $date_object
-					? esc_html( $date_object->format( $meeting_not_held ? $not_held_date_format : $held_date_format ) )
-					: '<span class="sr-text screen-reader-text">' . esc_html__( 'Date not available', 'edmm' ) . '</span>';
-
-				$agenda_item = $meeting_agenda_url
-					? apply_filters(
-						'edmm_meeting_agenda_link',
-						'<a href="' . esc_url( $meeting_agenda_url ) . '" aria-label="' . esc_attr(
-							sprintf(
-							/* translators: 1: link label e.g. "View Agenda", 2: meeting date */
-								__( '%1$s for %2$s', 'edmm' ),
-								$agenda_link_label,
-								wp_strip_all_tags( $formatted_date )
-							)
-						) . '">' . esc_html( $agenda_link_label ) . '</a>'
-					)
-					: '<span class="sr-text screen-reader-text">' . esc_html__( 'Agenda not available', 'edmm' ) . '</span>';
-
-				$minutes_item = $meeting_minutes_url
-					? apply_filters(
-						'edmm_meeting_minutes_link',
-						'<a href="' . esc_url( $meeting_minutes_url ) . '" aria-label="' . esc_attr(
-							sprintf(
-							/* translators: 1: link label e.g. "View Minutes", 2: meeting date */
-								__( '%1$s for %2$s', 'edmm' ),
-								$minutes_link_label,
-								wp_strip_all_tags( $formatted_date )
-							)
-						) . '">' . esc_html( $minutes_link_label ) . '</a>'
-					)
-					: '<span class="sr-text screen-reader-text">' . esc_html__( 'Minutes not available', 'edmm' ) . '</span>';
-
-				$row = [
-					'title'   => esc_html( get_the_title() ),
-					'date'    => $formatted_date,
-					'agenda'  => $meeting_not_held ? esc_html__( 'Meeting not held', 'edmm' ) : $agenda_item,
-					'minutes' => $minutes_item,
-				];
-
-				/**
-				 * Filters a single meeting row before it is added to the response.
-				 * Pro plugin can add extra fields (e.g., category, attachments).
-				 *
-				 * @param array    $row     The meeting row data.
-				 * @param int      $post_id The post ID.
-				 * @param \WP_REST_Request $request The REST request.
-				 */
-				$meetings[] = apply_filters( 'edmm_meeting_row_data', $row, $post_id, $request );
+				$meetings[] = $this->build_meeting_row(
+					get_the_ID(),
+					[
+						'held_date_format'     => $held_date_format,
+						'not_held_date_format' => $not_held_date_format,
+						'agenda_link_label'    => $agenda_link_label,
+						'minutes_link_label'   => $minutes_link_label,
+					],
+					$request
+				);
 			}
 			wp_reset_postdata();
 		}
@@ -224,6 +188,93 @@ class MeetingMinutesEndpoint {
 		$response = apply_filters( 'edmm_rest_response', $response, $request );
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Builds the public-facing row data for a single meeting minutes post.
+	 *
+	 * Extracted so Pro plugin features that need the exact same
+	 * escaped/formatted output as this endpoint (CSV/PDF export, an iCal
+	 * feed, a "most recent meeting" widget) can call this directly instead
+	 * of re-implementing the same escaping logic themselves.
+	 *
+	 * @param int                   $post_id     The meeting minutes post ID.
+	 * @param array                 $format_args {
+	 *    Formatting options.
+	 *
+	 *     @type string $held_date_format     PHP date() format for held meetings.
+	 *     @type string $not_held_date_format PHP date() format for not-held meetings.
+	 *     @type string $agenda_link_label    Link text for the agenda link.
+	 *     @type string $minutes_link_label   Link text for the minutes link.
+	 * }
+	 * @param \WP_REST_Request|null $request     The originating REST request, if any.
+	 * @return array
+	 */
+	public function build_meeting_row( int $post_id, array $format_args, ?\WP_REST_Request $request = null ): array {
+		$held_date_format     = $format_args['held_date_format'] ?? 'Y/m/d';
+		$not_held_date_format = $format_args['not_held_date_format'] ?? 'Y/m';
+		$agenda_link_label    = ! empty( $format_args['agenda_link_label'] ) ? $format_args['agenda_link_label'] : __( 'View Agenda', 'edmm' );
+		$minutes_link_label   = ! empty( $format_args['minutes_link_label'] ) ? $format_args['minutes_link_label'] : __( 'View Minutes', 'edmm' );
+
+		$meeting_date        = get_post_meta( $post_id, 'edmm_meeting_date', true );
+		$meeting_not_held    = (bool) get_post_meta( $post_id, 'edmm_meeting_not_held', true );
+		$meeting_agenda_url  = get_post_meta( $post_id, 'edmm_meeting_agenda_url', true );
+		$meeting_minutes_url = get_post_meta( $post_id, 'edmm_meeting_minutes_url', true );
+
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- intentional, gated behind WP_DEBUG for troubleshooting date parsing.
+			error_log( 'EDMM: Raw meeting date for post ' . $post_id . ': ' . $meeting_date );
+		}
+
+		$date_object    = $this->parse_date( $meeting_date );
+		$formatted_date = $date_object
+			? esc_html( $date_object->format( $meeting_not_held ? $not_held_date_format : $held_date_format ) )
+			: '<span class="sr-text screen-reader-text">' . esc_html__( 'Date not available', 'edmm' ) . '</span>';
+
+		$agenda_item = $meeting_agenda_url
+			? apply_filters(
+				'edmm_meeting_agenda_link',
+				'<a href="' . esc_url( $meeting_agenda_url ) . '" aria-label="' . esc_attr(
+					sprintf(
+					/* translators: 1: link label e.g. "View Agenda", 2: meeting date */
+						__( '%1$s for %2$s', 'edmm' ),
+						$agenda_link_label,
+						wp_strip_all_tags( $formatted_date )
+					)
+				) . '">' . esc_html( $agenda_link_label ) . '</a>'
+			)
+			: '<span class="sr-text screen-reader-text">' . esc_html__( 'Agenda not available', 'edmm' ) . '</span>';
+
+		$minutes_item = $meeting_minutes_url
+			? apply_filters(
+				'edmm_meeting_minutes_link',
+				'<a href="' . esc_url( $meeting_minutes_url ) . '" aria-label="' . esc_attr(
+					sprintf(
+					/* translators: 1: link label e.g. "View Minutes", 2: meeting date */
+						__( '%1$s for %2$s', 'edmm' ),
+						$minutes_link_label,
+						wp_strip_all_tags( $formatted_date )
+					)
+				) . '">' . esc_html( $minutes_link_label ) . '</a>'
+			)
+			: '<span class="sr-text screen-reader-text">' . esc_html__( 'Minutes not available', 'edmm' ) . '</span>';
+
+		$row = [
+			'title'   => esc_html( get_the_title( $post_id ) ),
+			'date'    => $formatted_date,
+			'agenda'  => $meeting_not_held ? esc_html__( 'Meeting not held', 'edmm' ) : $agenda_item,
+			'minutes' => $minutes_item,
+		];
+
+		/**
+		 * Filters a single meeting row before it is added to the response.
+		 * Pro plugin can add extra fields (e.g., category, attachments).
+		 *
+		 * @param array                  $row     The meeting row data.
+		 * @param int                    $post_id The post ID.
+		 * @param \WP_REST_Request|null $request  The REST request, if any.
+		 */
+		return apply_filters( 'edmm_meeting_row_data', $row, $post_id, $request );
 	}
 
 	/**

--- a/src/Shortcode/MeetingMinutesShortcode.php
+++ b/src/Shortcode/MeetingMinutesShortcode.php
@@ -200,6 +200,17 @@ class MeetingMinutesShortcode {
 			class="edmm-meeting-minutes-wrap"
 			data-config="<?php echo esc_attr( wp_json_encode( $instance_config ) ); ?>"
 		>
+			<?php
+			/**
+			 * Fires inside the shortcode wrapper, before the table container.
+			 * Pro plugin can use this to render e.g. a search box, a date
+			 * range picker, or an "add to calendar" button.
+			 *
+			 * @param string $instance_id The unique instance ID for this shortcode invocation.
+			 * @param array  $atts        The resolved shortcode attributes.
+			 */
+			do_action( 'edmm_before_table', $instance_id, $atts );
+			?>
 			<div id="edmm-table-<?php echo esc_attr( $instance_id ); ?>" class="edmm-table-container"></div>
 			<div id="edmm-pagination-<?php echo esc_attr( $instance_id ); ?>" class="edmm-pagination-container"></div>
 			<div
@@ -209,6 +220,17 @@ class MeetingMinutesShortcode {
 				aria-atomic="true"
 				style="position: absolute; left: -9999px;"
 			></div>
+			<?php
+			/**
+			 * Fires inside the shortcode wrapper, after the table container.
+			 * Pro plugin can use this to render e.g. a comment/feedback form
+			 * or a print button.
+			 *
+			 * @param string $instance_id The unique instance ID for this shortcode invocation.
+			 * @param array  $atts        The resolved shortcode attributes.
+			 */
+			do_action( 'edmm_after_table', $instance_id, $atts );
+			?>
 		</div>
 		<?php
 		return ob_get_clean();


### PR DESCRIPTION
## Summary
Follow-up to a free/Pro architecture pass against `docs/PREMIUM-FEATURES.md`. Four extension-point gaps identified that would block several planned premium features from cleanly extending the free plugin (items 1, 2, 3, 5 from that review; item 4 - a display-template override system for the JS table renderer - is a bigger design question we're deliberately deferring to discuss separately).

- **`edmm_cpt_args` filter** (`MeetingMinutes.php`) — CPT registration args (`public`, `rewrite`, `has_archive`, capabilities) were hardcoded. Needed for: approval workflow (custom capabilities), an auto-generated archive page, an RSS feed - anything that needs the CPT to be less "private" than the free plugin's default.
- **`edmm_rest_route_args` filter** (`MeetingMinutesEndpoint::register_route()`) — the REST route's registered `args` schema was hardcoded. Lets Pro add new params (full-text search, a date range) to the *same* route instead of standing up a duplicate route that re-implements the same query logic.
- **Extracted `build_meeting_row()`** — the per-row escaping/formatting logic (the exact code we hardened against XSS a few PRs ago) lived inline in `get_meeting_minutes()`'s loop. CSV/PDF export, an iCal feed, and a "most recent meeting" widget all need this same output; without extracting it, Pro would have had to duplicate the escaping logic, risking reintroducing the same bugs in a second copy. Also fixed `get_the_title()` to take an explicit `$post_id` so the method works standalone outside a `WP_Query` loop (previously relied on the loop's global post state).
- **`edmm_before_table` / `edmm_after_table` action hooks** (`MeetingMinutesShortcode::render()`) — lightweight extension point for things like a search box, an "add to calendar" button, or a comment form that don't need a full display-template override.

## Test plan
- [x] `composer lint` (php-parallel-lint) passes
- [x] `composer check-cs -- --report-full --ignore=vendor` passes
- [x] `npx wp-scripts lint-js assets/js/meeting-minutes.js` passes (JS unchanged by this PR)
- [x] Traced `build_meeting_row()` against the original inline loop code - identical logic, only `get_the_title()` now takes an explicit post ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more extension points around meeting minutes display and REST output, making it easier to customize content and route parameters.
  * Added optional hooks before and after the meeting minutes table for custom markup or UI.

* **Bug Fixes**
  * Improved meeting minutes row handling to better support different rendering contexts and reduce formatting inconsistencies.

* **Documentation**
  * Added guidance on hook compatibility and callback requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->