### PR TITLE
Add test coverage for REST endpoint and shortcode security fixes

### DIFF
--- a/src/REST/MeetingMinutesEndpoint.php
+++ b/src/REST/MeetingMinutesEndpoint.php
@@ -286,6 +286,12 @@ class MeetingMinutesEndpoint {
 	 * escape syntax. Also caps the length to avoid feeding pathologically
 	 * long strings into DateTime::format() once per result row.
 	 *
+	 * Requires at least one character: an empty string would otherwise
+	 * pass (trivially matching zero repetitions) and silently produce a
+	 * blank date instead of falling back to the field's own default -
+	 * notably when sanitize_text_field() strips a disallowed value like
+	 * "<script>" down to "" before it ever reaches this check.
+	 *
 	 * No type hint on $value: REST validate_callbacks can receive
 	 * non-string raw request values (e.g. an array from a repeated query
 	 * param), and a strict type hint would throw a TypeError instead of
@@ -298,7 +304,7 @@ class MeetingMinutesEndpoint {
 		if ( ! is_string( $value ) ) {
 			return false;
 		}
-		return strlen( $value ) <= 32 && (bool) preg_match( '/^[A-Za-z0-9\/\-.: ,]*$/', $value );
+		return strlen( $value ) <= 32 && (bool) preg_match( '/^[A-Za-z0-9\/\-.: ,]+$/', $value );
 	}
 
 	/**

--- a/tests/phpunit/MeetingMinutesEndpointBuildRowTest.php
+++ b/tests/phpunit/MeetingMinutesEndpointBuildRowTest.php
@@ -176,6 +176,40 @@ class MeetingMinutesEndpointBuildRowTest extends TestCase {
 	}
 
 	/**
+	 * A held meeting with no minutes URL gets the "not available" markup.
+	 *
+	 * Mirrors test_missing_agenda_url_falls_back_to_not_available() -
+	 * the agenda/minutes code paths are nearly identical, so a
+	 * copy-paste bug in one wouldn't be caught without covering both.
+	 */
+	public function test_missing_minutes_url_falls_back_to_not_available(): void {
+		$post_id = $this->create_meeting( [ 'edmm_meeting_date' => '2024-03-15' ] );
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertStringContainsString( 'Minutes not available', $row['minutes'] );
+	}
+
+	/**
+	 * A held meeting with a minutes URL gets a link built from it.
+	 *
+	 * Mirrors test_agenda_url_produces_a_link().
+	 */
+	public function test_minutes_url_produces_a_link(): void {
+		$post_id = $this->create_meeting(
+			[
+				'edmm_meeting_date'        => '2024-03-15',
+				'edmm_meeting_minutes_url' => 'https://example.com/minutes.pdf',
+			]
+		);
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertStringContainsString( 'href="https://example.com/minutes.pdf"', $row['minutes'] );
+		$this->assertStringContainsString( 'View Minutes', $row['minutes'] );
+	}
+
+	/**
 	 * Calling build_meeting_row() with no $request (e.g. from a future
 	 * non-REST caller like a CSV export) does not throw.
 	 */
@@ -193,17 +227,15 @@ class MeetingMinutesEndpointBuildRowTest extends TestCase {
 	public function test_row_data_filter_is_applied(): void {
 		$post_id = $this->create_meeting( [ 'edmm_meeting_date' => '2024-03-15' ] );
 
-		add_filter(
-			'edmm_meeting_row_data',
-			static function ( array $row ): array {
-				$row['custom_field'] = 'custom_value';
-				return $row;
-			}
-		);
+		$callback = static function ( array $row ): array {
+			$row['custom_field'] = 'custom_value';
+			return $row;
+		};
+		add_filter( 'edmm_meeting_row_data', $callback );
 
 		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
 
-		remove_all_filters( 'edmm_meeting_row_data' );
+		remove_filter( 'edmm_meeting_row_data', $callback );
 
 		$this->assertSame( 'custom_value', $row['custom_field'] );
 	}

--- a/tests/phpunit/MeetingMinutesEndpointBuildRowTest.php
+++ b/tests/phpunit/MeetingMinutesEndpointBuildRowTest.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Tests for MeetingMinutesEndpoint::build_meeting_row().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\REST\MeetingMinutesEndpoint;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the per-row output builder that was extracted for Pro plugin
+ * reuse (CSV/PDF export, iCal feed, widgets) - in particular the output
+ * escaping fixed after a stored-XSS finding where post titles were
+ * returned unescaped in the public REST response.
+ */
+class MeetingMinutesEndpointBuildRowTest extends TestCase {
+
+	/**
+	 * The endpoint instance under test.
+	 *
+	 * @var MeetingMinutesEndpoint
+	 */
+	private MeetingMinutesEndpoint $endpoint;
+
+	/**
+	 * Default format args matching the REST route's defaults.
+	 *
+	 * @var array<string, string>
+	 */
+	private array $default_format_args = [
+		'held_date_format'     => 'Y/m/d',
+		'not_held_date_format' => 'Y/m',
+		'agenda_link_label'    => 'View Agenda',
+		'minutes_link_label'   => 'View Minutes',
+	];
+
+	/**
+	 * Sets up a fresh endpoint instance for each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->endpoint = new MeetingMinutesEndpoint();
+	}
+
+	/**
+	 * Creates a meeting minutes post with the given meta.
+	 *
+	 * @param array $meta Meta key/value pairs to set on the post.
+	 * @param array $post_args Additional wp_insert_post args (e.g. post_title).
+	 * @return int The created post ID.
+	 */
+	private function create_meeting( array $meta = [], array $post_args = [] ): int {
+		$post_id = self::factory()->post->create(
+			array_merge(
+				[ 'post_type' => 'edmm_meeting_minutes' ],
+				$post_args
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * A post title containing markup is escaped in the output row, not
+	 * passed through raw - this is the fix for the stored XSS finding.
+	 *
+	 * Uses an administrator (has unfiltered_html on non-multisite) to
+	 * create the post, matching the real-world scenario: only a user
+	 * with unfiltered_html can get raw markup into post_title in the
+	 * first place, which is why this was exploitable by Editors too.
+	 */
+	public function test_title_is_escaped(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->create_meeting(
+			[ 'edmm_meeting_date' => '2024-03-15' ],
+			[ 'post_title' => '<script>alert(1)</script>' ]
+		);
+
+		wp_set_current_user( 0 );
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertStringNotContainsString( '<script>', $row['title'] );
+		$this->assertStringContainsString( '&lt;script&gt;', $row['title'] );
+	}
+
+	/**
+	 * A held meeting's date is formatted using held_date_format.
+	 */
+	public function test_held_meeting_date_uses_held_format(): void {
+		$post_id = $this->create_meeting( [ 'edmm_meeting_date' => '2024-03-15' ] );
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertSame( '2024/03/15', $row['date'] );
+	}
+
+	/**
+	 * A not-held meeting's date is formatted using not_held_date_format.
+	 */
+	public function test_not_held_meeting_date_uses_not_held_format(): void {
+		$post_id = $this->create_meeting(
+			[
+				'edmm_meeting_date'     => '2024-03-15',
+				'edmm_meeting_not_held' => '1',
+			]
+		);
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertSame( '2024/03', $row['date'] );
+	}
+
+	/**
+	 * A missing/unparseable date falls back to the "not available" markup.
+	 */
+	public function test_missing_date_falls_back_to_not_available(): void {
+		$post_id = $this->create_meeting();
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertStringContainsString( 'Date not available', $row['date'] );
+	}
+
+	/**
+	 * A meeting not held reports "Meeting not held" as its agenda text,
+	 * regardless of whether an agenda URL is set.
+	 */
+	public function test_not_held_meeting_agenda_text(): void {
+		$post_id = $this->create_meeting(
+			[
+				'edmm_meeting_date'        => '2024-03-15',
+				'edmm_meeting_not_held'    => '1',
+				'edmm_meeting_agenda_url'  => 'https://example.com/agenda.pdf',
+			]
+		);
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertSame( 'Meeting not held', $row['agenda'] );
+	}
+
+	/**
+	 * A held meeting with no agenda URL gets the "not available" markup.
+	 */
+	public function test_missing_agenda_url_falls_back_to_not_available(): void {
+		$post_id = $this->create_meeting( [ 'edmm_meeting_date' => '2024-03-15' ] );
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertStringContainsString( 'Agenda not available', $row['agenda'] );
+	}
+
+	/**
+	 * A held meeting with an agenda URL gets a link built from it.
+	 */
+	public function test_agenda_url_produces_a_link(): void {
+		$post_id = $this->create_meeting(
+			[
+				'edmm_meeting_date'       => '2024-03-15',
+				'edmm_meeting_agenda_url' => 'https://example.com/agenda.pdf',
+			]
+		);
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertStringContainsString( 'href="https://example.com/agenda.pdf"', $row['agenda'] );
+		$this->assertStringContainsString( 'View Agenda', $row['agenda'] );
+	}
+
+	/**
+	 * Calling build_meeting_row() with no $request (e.g. from a future
+	 * non-REST caller like a CSV export) does not throw.
+	 */
+	public function test_works_without_a_request_object(): void {
+		$post_id = $this->create_meeting( [ 'edmm_meeting_date' => '2024-03-15' ] );
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args, null );
+
+		$this->assertSame( '2024/03/15', $row['date'] );
+	}
+
+	/**
+	 * The edmm_meeting_row_data filter can add/override fields on the row.
+	 */
+	public function test_row_data_filter_is_applied(): void {
+		$post_id = $this->create_meeting( [ 'edmm_meeting_date' => '2024-03-15' ] );
+
+		add_filter(
+			'edmm_meeting_row_data',
+			static function ( array $row ): array {
+				$row['custom_field'] = 'custom_value';
+				return $row;
+			}
+		);
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		remove_all_filters( 'edmm_meeting_row_data' );
+
+		$this->assertSame( 'custom_value', $row['custom_field'] );
+	}
+}

--- a/tests/phpunit/MeetingMinutesEndpointRestTest.php
+++ b/tests/phpunit/MeetingMinutesEndpointRestTest.php
@@ -107,7 +107,13 @@ class MeetingMinutesEndpointRestTest extends TestCase {
 
 		$this->assertCount( 2, $data['meetings'] );
 		$this->assertSame( 3, $data['total_entries'] );
-		$this->assertSame( 2, $data['max_num_pages'] );
+		// assertEquals, not assertSame: WP_Query::$max_num_pages is
+		// ceil()'d, which returns float in PHP - whether that surfaces as
+		// int or float here varies by WP core version (confirmed via CI:
+		// WP 6.2 returns float(2.0), WP latest returns int(2)). The
+		// number of pages being 2 is the contract; the PHP-level type
+		// isn't.
+		$this->assertEquals( 2, $data['max_num_pages'] );
 	}
 
 	/**

--- a/tests/phpunit/MeetingMinutesEndpointRestTest.php
+++ b/tests/phpunit/MeetingMinutesEndpointRestTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Integration tests for the registered /edmm/v1/meeting-minutes/ REST route.
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Dispatches real requests through the REST server, rather than calling
+ * MeetingMinutesEndpoint's methods directly - this is the only coverage
+ * that proves register_route() is actually wired correctly (route path,
+ * args schema, validate_callback) rather than just proving the
+ * underlying functions work in isolation.
+ */
+class MeetingMinutesEndpointRestTest extends TestCase {
+
+	const ROUTE = '/edmm/v1/meeting-minutes';
+
+	/**
+	 * Ensures the REST server (and therefore rest_api_init/register_route)
+	 * has run before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+	}
+
+	/**
+	 * Creates a meeting minutes post with the given meta.
+	 *
+	 * @param array $meta Meta key/value pairs to set on the post.
+	 * @return int The created post ID.
+	 */
+	private function create_meeting( array $meta = [] ): int {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'edmm_meeting_minutes' ] );
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * A plain request against the real route returns 200 with the
+	 * expected top-level response shape.
+	 */
+	public function test_route_returns_expected_shape(): void {
+		$this->create_meeting( [ 'edmm_meeting_date' => '2024-03-15' ] );
+
+		$request  = new \WP_REST_Request( 'GET', self::ROUTE );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'meetings', $data );
+		$this->assertArrayHasKey( 'max_num_pages', $data );
+		$this->assertArrayHasKey( 'current_page', $data );
+		$this->assertArrayHasKey( 'total_entries', $data );
+		$this->assertCount( 1, $data['meetings'] );
+	}
+
+	/**
+	 * An invalid held_date_format is rejected with 400 by the route's
+	 * own validate_callback, end to end - not just by calling
+	 * validate_date_format() directly.
+	 */
+	public function test_invalid_held_date_format_is_rejected_with_400(): void {
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'held_date_format', '<script>' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * An invalid not_held_date_format is rejected with 400 too.
+	 */
+	public function test_invalid_not_held_date_format_is_rejected_with_400(): void {
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'not_held_date_format', '\\<\\s\\c\\r\\i\\p\\t\\>' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * posts_per_page is honored against real query results.
+	 */
+	public function test_posts_per_page_limits_results(): void {
+		$this->create_meeting( [ 'edmm_meeting_date' => '2024-01-01' ] );
+		$this->create_meeting( [ 'edmm_meeting_date' => '2024-06-01' ] );
+		$this->create_meeting( [ 'edmm_meeting_date' => '2024-12-01' ] );
+
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'posts_per_page', 2 );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertCount( 2, $data['meetings'] );
+		$this->assertSame( 3, $data['total_entries'] );
+		$this->assertSame( 2, $data['max_num_pages'] );
+	}
+
+	/**
+	 * included_years actually filters results against real meta_query
+	 * construction, not just the sanitized param value.
+	 */
+	public function test_included_years_filters_results(): void {
+		$this->create_meeting( [ 'edmm_meeting_date' => '2023-05-01' ] );
+		$this->create_meeting( [ 'edmm_meeting_date' => '2024-05-01' ] );
+
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'included_years', '2024' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 1, $data['total_entries'] );
+	}
+
+	/**
+	 * Posts without a meeting date meta value are excluded from results,
+	 * per the meta_query's EXISTS clause.
+	 */
+	public function test_posts_without_meeting_date_are_excluded(): void {
+		$this->create_meeting(); // No edmm_meeting_date meta at all.
+
+		$request  = new \WP_REST_Request( 'GET', self::ROUTE );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 0, $data['total_entries'] );
+	}
+}

--- a/tests/phpunit/MeetingMinutesEndpointValidateDateFormatTest.php
+++ b/tests/phpunit/MeetingMinutesEndpointValidateDateFormatTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Tests for MeetingMinutesEndpoint::validate_date_format().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\REST\MeetingMinutesEndpoint;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the REST validate_callback that gates held_date_format/
+ * not_held_date_format, added to close a potential XSS vector where an
+ * unauthenticated caller could otherwise control a PHP DateTime format
+ * string reflected back in the public REST response.
+ */
+class MeetingMinutesEndpointValidateDateFormatTest extends TestCase {
+
+	/**
+	 * Ordinary date format strings are accepted.
+	 *
+	 * @dataProvider provide_valid_formats
+	 * @param string $format Format string under test.
+	 */
+	public function test_accepts_valid_formats( string $format ): void {
+		$this->assertTrue( MeetingMinutesEndpoint::validate_date_format( $format ) );
+	}
+
+	/**
+	 * Data provider for valid date formats.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_valid_formats(): array {
+		return [
+			'default held format'     => [ 'Y/m/d' ],
+			'default not-held format' => [ 'Y/m' ],
+			'with time and dashes'    => [ 'Y-m-d H:i:s' ],
+			'empty string'            => [ '' ],
+		];
+	}
+
+	/**
+	 * Rejects the backslash-escape trick that would otherwise force
+	 * DateTime::format() to emit arbitrary literal characters, including
+	 * ones that aren't allowed on their own (like angle brackets).
+	 */
+	public function test_rejects_backslash_escaped_payload(): void {
+		$this->assertFalse( MeetingMinutesEndpoint::validate_date_format( '\\<\\s\\c\\r\\i\\p\\t\\>' ) );
+	}
+
+	/**
+	 * Rejects a literal disallowed character even without any escaping.
+	 */
+	public function test_rejects_disallowed_characters(): void {
+		$this->assertFalse( MeetingMinutesEndpoint::validate_date_format( '<script>' ) );
+	}
+
+	/**
+	 * Non-string input (e.g. an array from a repeated query param) must
+	 * fail validation cleanly rather than throw a TypeError.
+	 */
+	public function test_rejects_non_string_input_without_throwing(): void {
+		$this->assertFalse( MeetingMinutesEndpoint::validate_date_format( [ 'not', 'a', 'string' ] ) );
+	}
+
+	/**
+	 * Overly long input is rejected even if every character is otherwise
+	 * allowed, to avoid feeding pathologically long strings into
+	 * DateTime::format() once per result row.
+	 */
+	public function test_rejects_overly_long_input(): void {
+		$this->assertFalse( MeetingMinutesEndpoint::validate_date_format( str_repeat( 'Y', 33 ) ) );
+	}
+
+	/**
+	 * Input at exactly the length limit is still accepted.
+	 */
+	public function test_accepts_input_at_length_limit(): void {
+		$this->assertTrue( MeetingMinutesEndpoint::validate_date_format( str_repeat( 'Y', 32 ) ) );
+	}
+}

--- a/tests/phpunit/MeetingMinutesEndpointValidateDateFormatTest.php
+++ b/tests/phpunit/MeetingMinutesEndpointValidateDateFormatTest.php
@@ -36,8 +36,20 @@ class MeetingMinutesEndpointValidateDateFormatTest extends TestCase {
 			'default held format'     => [ 'Y/m/d' ],
 			'default not-held format' => [ 'Y/m' ],
 			'with time and dashes'    => [ 'Y-m-d H:i:s' ],
-			'empty string'            => [ '' ],
 		];
+	}
+
+	/**
+	 * An empty string is rejected rather than accepted, since a
+	 * REST/shortcode caller only sees the field's own default applied
+	 * when the param is omitted entirely - an explicit empty value must
+	 * fail validation, or it would silently produce a blank date instead
+	 * of falling back to the default. This also matters because
+	 * sanitize_text_field() reduces a disallowed value like "<script>"
+	 * down to "" before validate_date_format() ever sees it.
+	 */
+	public function test_rejects_empty_string(): void {
+		$this->assertFalse( MeetingMinutesEndpoint::validate_date_format( '' ) );
 	}
 
 	/**

--- a/tests/phpunit/MeetingMinutesShortcodeTest.php
+++ b/tests/phpunit/MeetingMinutesShortcodeTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for MeetingMinutesShortcode::render().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\Shortcode\MeetingMinutesShortcode;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the shortcode's public render() contract - in particular the
+ * class-attribute sanitization (stored XSS fix) and the date-format
+ * validation/fallback (fix for the shortcode silently breaking the
+ * whole table when given an invalid held_date_format/not_held_date_format).
+ *
+ * sanitize_class_list()/sanitize_date_format() are private, so these
+ * tests go through the public render() output rather than reflection -
+ * that keeps the tests tied to the actual observable contract.
+ */
+class MeetingMinutesShortcodeTest extends TestCase {
+
+	/**
+	 * The shortcode instance under test.
+	 *
+	 * @var MeetingMinutesShortcode
+	 */
+	private MeetingMinutesShortcode $shortcode;
+
+	/**
+	 * Sets up a fresh shortcode instance for each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->shortcode = new MeetingMinutesShortcode();
+	}
+
+	/**
+	 * Decodes the instance config JSON out of a render() output string.
+	 *
+	 * @param string $html The HTML returned by render().
+	 * @return array<string, mixed>
+	 */
+	private function get_instance_config( string $html ): array {
+		$this->assertMatchesRegularExpression( '/data-config="([^"]*)"/', $html );
+		preg_match( '/data-config="([^"]*)"/', $html, $matches );
+		$json = html_entity_decode( $matches[1], ENT_QUOTES );
+		return json_decode( $json, true );
+	}
+
+	/**
+	 * A `class` attribute containing an attribute-breakout attempt is
+	 * reduced to safe class-name characters only.
+	 *
+	 * Note: sanitize_html_class() strips per-token to safe class-name
+	 * characters, but harmless-looking words like "onmouseover" remain
+	 * as a (meaningless but inert) class name - what actually matters is
+	 * that no attribute-breakout characters (", <, >, =, (, )) survive,
+	 * since those are what would let the value escape the class="..."
+	 * attribute context it's rendered into client-side.
+	 */
+	public function test_class_attribute_is_sanitized(): void {
+		$html   = $this->shortcode->render( [ 'class' => 'foo" onmouseover="alert(1)' ] );
+		$config = $this->get_instance_config( $html );
+
+		foreach ( [ '"', '<', '>', '=', '(', ')' ] as $dangerous_char ) {
+			$this->assertStringNotContainsString( $dangerous_char, $config['tableClass'] );
+		}
+	}
+
+	/**
+	 * A plain, valid class list passes through unchanged.
+	 */
+	public function test_valid_class_attribute_is_preserved(): void {
+		$html   = $this->shortcode->render( [ 'class' => 'my-custom-class another-class' ] );
+		$config = $this->get_instance_config( $html );
+
+		$this->assertSame( 'my-custom-class another-class', $config['tableClass'] );
+	}
+
+	/**
+	 * An invalid held_date_format falls back to the default rather than
+	 * reaching the REST call and breaking the whole table.
+	 */
+	public function test_invalid_held_date_format_falls_back_to_default(): void {
+		$html   = $this->shortcode->render( [ 'held_date_format' => '\\<\\s\\c\\r\\i\\p\\t\\>' ] );
+		$config = $this->get_instance_config( $html );
+
+		$this->assertSame( 'Y/m/d', $config['heldDateFormat'] );
+	}
+
+	/**
+	 * An invalid not_held_date_format falls back to its default too.
+	 */
+	public function test_invalid_not_held_date_format_falls_back_to_default(): void {
+		$html   = $this->shortcode->render( [ 'not_held_date_format' => '<script>' ] );
+		$config = $this->get_instance_config( $html );
+
+		$this->assertSame( 'Y/m', $config['notHeldDateFormat'] );
+	}
+
+	/**
+	 * A valid custom date format is preserved rather than replaced.
+	 */
+	public function test_valid_date_format_is_preserved(): void {
+		$html   = $this->shortcode->render( [ 'held_date_format' => 'F j, Y' ] );
+		$config = $this->get_instance_config( $html );
+
+		$this->assertSame( 'F j, Y', $config['heldDateFormat'] );
+	}
+
+	/**
+	 * Each shortcode invocation gets a unique instance ID, so multiple
+	 * instances on the same page don't collide.
+	 */
+	public function test_multiple_instances_get_unique_ids(): void {
+		$first_config  = $this->get_instance_config( $this->shortcode->render( [] ) );
+		$second_config = $this->get_instance_config( $this->shortcode->render( [] ) );
+
+		$this->assertNotSame( $first_config['instanceId'], $second_config['instanceId'] );
+	}
+}

--- a/tests/phpunit/MeetingMinutesShortcodeTest.php
+++ b/tests/phpunit/MeetingMinutesShortcodeTest.php
@@ -42,10 +42,14 @@ class MeetingMinutesShortcodeTest extends TestCase {
 	 * @return array<string, mixed>
 	 */
 	private function get_instance_config( string $html ): array {
-		$this->assertMatchesRegularExpression( '/data-config="([^"]*)"/', $html );
-		preg_match( '/data-config="([^"]*)"/', $html, $matches );
-		$json = html_entity_decode( $matches[1], ENT_QUOTES );
-		return json_decode( $json, true );
+		$matched = preg_match( '/data-config="([^"]*)"/', $html, $matches );
+		$this->assertSame( 1, $matched, 'The data-config attribute was not found in the HTML.' );
+
+		$json   = html_entity_decode( $matches[1], ENT_QUOTES );
+		$config = json_decode( $json, true );
+		$this->assertIsArray( $config );
+
+		return $config;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Test coverage for the security-critical code touched in the recent XSS-fix and Pro-extension-hooks PRs, which had zero coverage beyond one plugin-bootstrap smoke test.

- **`validate_date_format()`** — allow-list acceptance/rejection, the backslash-escape trick, non-string input (no TypeError), and the 32-char length cap at its boundary.
- **`build_meeting_row()`** — title escaping (the stored XSS fix, tested via an administrator user since only `unfiltered_html` users can get raw markup into a post title in the first place), held/not-held date formatting, missing-date/agenda/minutes fallback markup, agenda link construction, working without a `$request` object, and the `edmm_meeting_row_data` filter being applied.
- **Shortcode `render()`** — class-attribute sanitization and date-format validation/fallback, tested through the public `data-config` output rather than reflection into the private sanitizer methods.

**Found and fixed a real bug while writing these tests:** `validate_date_format()`'s regex used `*` instead of `+`, so an empty string trivially matched and was treated as valid. Since `sanitize_text_field()` reduces a disallowed value like `<script>` down to `""` before validation ever runs, this silently bypassed the "fall back to the default on invalid input" behavior for exactly the kind of input it was meant to catch - producing a blank date instead of the intended default format. Not itself a security bug (an empty format string is harmless), but a real correctness regression from the intended behavior. Fixed by requiring at least one character.

## Test plan
- [x] `docker compose exec phpunit vendor/bin/phpunit` — 27 tests, 44 assertions, all passing
- [x] `composer lint` / `composer check-cs` pass
- [x] Confirmed the empty-string fix doesn't affect any currently-valid format string (`Y/m/d`, `Y-m-d H:i:s`, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date format validation so empty or invalid formats are rejected, helping prevent broken date display.
  * Strengthened meeting row output to better handle missing dates, missing agenda links, and non-held meetings.
  * Added safer handling for meeting titles and shortcode attributes to reduce the risk of unsafe HTML appearing in output.
  * Ensured repeated shortcode usage keeps each meeting table instance separate and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->