### PR TITLE
Stop Test and Security workflows double-running on PR pushes

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,7 +1,13 @@
 name: Test
 
 on:
+  # Only run on push for direct pushes to main - PR branches are already
+  # covered by pull_request below, and an unrestricted push trigger runs
+  # this workflow twice per PR commit (once per event type, each with a
+  # different github.ref so they don't share a concurrency group).
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,13 @@
 name: Security
 
 on:
-  # Run on all pushes and on all pull requests.
+  # Only run on push for direct pushes to main - PR branches are already
+  # covered by pull_request below, and an unrestricted push trigger runs
+  # this workflow twice per PR commit (once per event type, each with a
+  # different github.ref so they don't share a concurrency group).
   push:
+    branches:
+      - main
   pull_request:
   # Also run this workflow every Monday at 6:00.
   schedule:


### PR DESCRIPTION
## Summary
Noticed while working on PR #10: `Test:` and `Security check:` entries always showed up twice in every PR's checks list.

Root cause: `phpunit.yml` ("Test") and `security.yml` ("Security") both had an unrestricted `push:` trigger alongside `pull_request:`. A commit to a PR branch fires both event types. Each event type produces a different `github.ref` (`refs/heads/<branch>` for push vs. `refs/pull/<pr>/merge` for pull_request), so their `concurrency` group (keyed on `${{ github.ref }}`) doesn't overlap and they don't cancel each other - every PR commit ran the full PHP/WP version test matrix and the security check twice, doubling CI minutes for those two workflows on every push.

(For comparison, `cs.yml`/`lint-js.yml`/`lint-php.yml` don't have this problem unconditionally - they already restrict `push:` to specific branch patterns, though which patterns get double-triggered varies by branch naming coincidence. Out of scope here; flagging only in case it's worth a follow-up.)

Fix: restrict `push:` on both workflows to `main` only. `pull_request:` already covers validation on every PR branch regardless of name, so this doesn't lose any coverage - it just stops redundantly re-running the same commit's validation twice.

## Test plan
- [x] Validated both workflow files parse as valid YAML
- [x] This PR itself will show whether Test/Security now run once instead of twice in its own checks list