### PR TITLE
Expand test coverage: MetaBox, Plugin, PostType, SettingsPage

### DIFF
--- a/tests/phpunit/MeetingMinutesPostTypeTest.php
+++ b/tests/phpunit/MeetingMinutesPostTypeTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests for PostType\MeetingMinutes::register_post_type().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\PostType\MeetingMinutes as MeetingMinutesCPT;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the CPT's registered args (the intentionally-documented
+ * public/show_in_rest combination) and the edmm_cpt_args filter added
+ * so Pro can enable public/rewrite/archive support.
+ */
+class MeetingMinutesPostTypeTest extends TestCase {
+
+	/**
+	 * The edmm_meeting_minutes post type is registered.
+	 */
+	public function test_cpt_is_registered(): void {
+		$this->assertTrue( post_type_exists( 'edmm_meeting_minutes' ) );
+	}
+
+	/**
+	 * The CPT's registered args match the documented, intentional
+	 * defaults (public => false but show_in_rest => true).
+	 */
+	public function test_cpt_has_documented_default_args(): void {
+		$post_type_object = get_post_type_object( 'edmm_meeting_minutes' );
+
+		$this->assertFalse( $post_type_object->public );
+		$this->assertTrue( $post_type_object->show_in_rest );
+		$this->assertFalse( $post_type_object->has_archive );
+	}
+
+	/**
+	 * The edmm_cpt_args filter receives the registration args before
+	 * register_post_type() is called, so Pro can modify them (e.g. to
+	 * enable public/rewrite/archive support for an approval workflow or
+	 * archive page).
+	 */
+	public function test_edmm_cpt_args_filter_receives_registration_args(): void {
+		$captured_args = null;
+		$callback      = static function ( array $args ) use ( &$captured_args ): array {
+			$captured_args = $args;
+			return $args;
+		};
+		add_filter( 'edmm_cpt_args', $callback );
+
+		unregister_post_type( 'edmm_meeting_minutes' );
+		( new MeetingMinutesCPT() )->register_post_type();
+
+		remove_filter( 'edmm_cpt_args', $callback );
+
+		$this->assertIsArray( $captured_args );
+		$this->assertArrayHasKey( 'public', $captured_args );
+		$this->assertFalse( $captured_args['public'] );
+	}
+
+	/**
+	 * A callback on edmm_cpt_args can actually change the registered
+	 * CPT's behavior, not just observe the args.
+	 */
+	public function test_edmm_cpt_args_filter_can_change_registration(): void {
+		$callback = static function ( array $args ): array {
+			$args['public'] = true;
+			return $args;
+		};
+		add_filter( 'edmm_cpt_args', $callback );
+
+		try {
+			unregister_post_type( 'edmm_meeting_minutes' );
+			( new MeetingMinutesCPT() )->register_post_type();
+
+			$post_type_object = get_post_type_object( 'edmm_meeting_minutes' );
+			$this->assertTrue( $post_type_object->public );
+		} finally {
+			// Restore the CPT to its normal registration for subsequent
+			// tests, even if the assertion above failed.
+			remove_filter( 'edmm_cpt_args', $callback );
+			unregister_post_type( 'edmm_meeting_minutes' );
+			( new MeetingMinutesCPT() )->register_post_type();
+		}
+	}
+}

--- a/tests/phpunit/MetaBoxAddMetaBoxTest.php
+++ b/tests/phpunit/MetaBoxAddMetaBoxTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for MetaBox::add_meta_box().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\Admin\MetaBox;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the edmm_use_native_meta_boxes filter, the documented
+ * extension point that lets Pro (or another integration) fully
+ * replace the native meta box UI.
+ */
+class MetaBoxAddMetaBoxTest extends TestCase {
+
+	/**
+	 * Clears any previously registered meta box for this screen so each
+	 * test starts from a known state.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		global $wp_meta_boxes;
+		unset( $wp_meta_boxes['edmm_meeting_minutes'] );
+	}
+
+	/**
+	 * By default (filter untouched), the native meta box is registered.
+	 */
+	public function test_meta_box_is_registered_by_default(): void {
+		( new MetaBox() )->add_meta_box();
+
+		global $wp_meta_boxes;
+		$this->assertArrayHasKey( 'edmm_meeting_details', $wp_meta_boxes['edmm_meeting_minutes']['normal']['high'] );
+	}
+
+	/**
+	 * Returning false from edmm_use_native_meta_boxes suppresses the
+	 * native meta box entirely, so Pro can render its own instead.
+	 */
+	public function test_filter_can_suppress_native_meta_box(): void {
+		add_filter( 'edmm_use_native_meta_boxes', '__return_false' );
+
+		( new MetaBox() )->add_meta_box();
+
+		remove_filter( 'edmm_use_native_meta_boxes', '__return_false' );
+
+		global $wp_meta_boxes;
+		$this->assertArrayNotHasKey( 'edmm_meeting_minutes', (array) $wp_meta_boxes );
+	}
+}

--- a/tests/phpunit/MetaBoxRegisterMetaTest.php
+++ b/tests/phpunit/MetaBoxRegisterMetaTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Tests for MetaBox::register_post_meta().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\Admin\MetaBox;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the registered meta schema (sanitize_callback per field) and,
+ * most importantly, the auth_callback's object_id handling - this is
+ * what Gemini Code Assist flagged as a regression risk when the
+ * auth_callback was tightened from a blanket edit_posts check to a
+ * post-specific edit_post check.
+ */
+class MetaBoxRegisterMetaTest extends TestCase {
+
+	/**
+	 * Re-registers the meta fields before each test - WP's per-test
+	 * global reset can clear $wp_meta_keys between tests, and
+	 * register_post_meta() is idempotent, so calling it directly here
+	 * guarantees the schema is present regardless of bootstrap timing.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		( new MetaBox() )->register_post_meta();
+	}
+
+	/**
+	 * Returns the registered meta args for one of the plugin's meta keys.
+	 *
+	 * @param string $meta_key The meta key.
+	 * @return array
+	 */
+	private function get_meta_args( string $meta_key ): array {
+		global $wp_meta_keys;
+		return $wp_meta_keys['post']['edmm_meeting_minutes'][ $meta_key ];
+	}
+
+	/**
+	 * All four meeting meta fields are registered as single, REST-visible
+	 * fields on the CPT.
+	 */
+	public function test_all_meta_keys_are_registered(): void {
+		global $wp_meta_keys;
+		$keys = array_keys( $wp_meta_keys['post']['edmm_meeting_minutes'] );
+
+		foreach ( [ 'edmm_meeting_date', 'edmm_meeting_agenda_url', 'edmm_meeting_minutes_url', 'edmm_meeting_not_held' ] as $expected_key ) {
+			$this->assertContains( $expected_key, $keys );
+		}
+	}
+
+	/**
+	 * Text-type fields use sanitize_text_field.
+	 */
+	public function test_text_fields_use_sanitize_text_field(): void {
+		$this->assertSame( 'sanitize_text_field', $this->get_meta_args( 'edmm_meeting_date' )['sanitize_callback'] );
+		$this->assertSame( 'sanitize_text_field', $this->get_meta_args( 'edmm_meeting_not_held' )['sanitize_callback'] );
+	}
+
+	/**
+	 * URL fields use esc_url_raw, matching the sanitization used again
+	 * at save time in MetaBox::save_meta().
+	 */
+	public function test_url_fields_use_esc_url_raw(): void {
+		$this->assertSame( 'esc_url_raw', $this->get_meta_args( 'edmm_meeting_agenda_url' )['sanitize_callback'] );
+		$this->assertSame( 'esc_url_raw', $this->get_meta_args( 'edmm_meeting_minutes_url' )['sanitize_callback'] );
+	}
+
+	/**
+	 * With a real post ID, the auth_callback checks edit_post capability
+	 * for that specific post - a user who can't edit the post is denied
+	 * even if they could edit posts of this type in general.
+	 */
+	public function test_auth_callback_denies_user_without_post_specific_capability(): void {
+		$post_id       = self::factory()->post->create( [ 'post_type' => 'edmm_meeting_minutes' ] );
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$auth_callback = $this->get_meta_args( 'edmm_meeting_date' )['auth_callback'];
+		$allowed       = $auth_callback( true, 'edmm_meeting_date', $post_id );
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $allowed );
+	}
+
+	/**
+	 * With a real post ID, a user who can edit that post is allowed.
+	 */
+	public function test_auth_callback_allows_user_with_post_specific_capability(): void {
+		$post_id   = self::factory()->post->create( [ 'post_type' => 'edmm_meeting_minutes' ] );
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+
+		$auth_callback = $this->get_meta_args( 'edmm_meeting_date' )['auth_callback'];
+		$allowed       = $auth_callback( true, 'edmm_meeting_date', $post_id );
+
+		wp_set_current_user( 0 );
+
+		$this->assertTrue( $allowed );
+	}
+
+	/**
+	 * With object_id 0 (e.g. authorizing meta for a post that doesn't
+	 * exist yet, such as during new-post creation via the REST API),
+	 * the auth_callback falls back to the general edit_posts capability
+	 * instead of denying via current_user_can( 'edit_post', 0 ), which
+	 * always returns false. This is the fix for the regression Gemini
+	 * Code Assist flagged.
+	 */
+	public function test_auth_callback_falls_back_to_edit_posts_when_object_id_is_zero(): void {
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+
+		$auth_callback = $this->get_meta_args( 'edmm_meeting_date' )['auth_callback'];
+		$allowed       = $auth_callback( true, 'edmm_meeting_date', 0 );
+
+		wp_set_current_user( 0 );
+
+		$this->assertTrue( $allowed );
+	}
+
+	/**
+	 * A logged-out user is denied even with object_id 0.
+	 */
+	public function test_auth_callback_denies_logged_out_user_with_zero_object_id(): void {
+		wp_set_current_user( 0 );
+
+		$auth_callback = $this->get_meta_args( 'edmm_meeting_date' )['auth_callback'];
+		$allowed       = $auth_callback( true, 'edmm_meeting_date', 0 );
+
+		$this->assertFalse( $allowed );
+	}
+}

--- a/tests/phpunit/MetaBoxSaveMetaTest.php
+++ b/tests/phpunit/MetaBoxSaveMetaTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Tests for MetaBox::save_meta().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\Admin\MetaBox;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the meta box save handler's nonce/capability gating and
+ * per-field sanitization - this is the plugin's only direct-$_POST
+ * write path, so it's the highest-value target for authorization and
+ * sanitization regression coverage.
+ */
+class MetaBoxSaveMetaTest extends TestCase {
+
+	/**
+	 * The MetaBox instance under test.
+	 *
+	 * @var MetaBox
+	 */
+	private MetaBox $meta_box;
+
+	/**
+	 * The post ID used across tests.
+	 *
+	 * @var int
+	 */
+	private int $post_id;
+
+	/**
+	 * Sets up a fresh MetaBox instance, test post, and valid POST/nonce
+	 * baseline for each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->meta_box = new MetaBox();
+		$this->post_id  = self::factory()->post->create( [ 'post_type' => 'edmm_meeting_minutes' ] );
+
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+
+		$_POST = [
+			'edmm_meeting_meta_nonce' => wp_create_nonce( 'edmm_save_meeting_meta' ),
+		];
+	}
+
+	/**
+	 * Resets $_POST and the current user after each test.
+	 */
+	public function tear_down(): void {
+		$_POST = [];
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Without the nonce field present at all, nothing is saved.
+	 */
+	public function test_missing_nonce_saves_nothing(): void {
+		$_POST = [ 'edmm_meeting_date' => '2024-03-15' ];
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '', get_post_meta( $this->post_id, 'edmm_meeting_date', true ) );
+	}
+
+	/**
+	 * An invalid/forged nonce is rejected.
+	 */
+	public function test_invalid_nonce_saves_nothing(): void {
+		$_POST['edmm_meeting_meta_nonce'] = 'not-a-real-nonce';
+		$_POST['edmm_meeting_date']       = '2024-03-15';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '', get_post_meta( $this->post_id, 'edmm_meeting_date', true ) );
+	}
+
+	/**
+	 * A valid nonce but a user without edit_post capability for this
+	 * post is rejected.
+	 */
+	public function test_user_without_capability_saves_nothing(): void {
+		wp_set_current_user( 0 ); // Logged out - no capabilities at all.
+
+		$_POST['edmm_meeting_date'] = '2024-03-15';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '', get_post_meta( $this->post_id, 'edmm_meeting_date', true ) );
+	}
+
+	/**
+	 * A well-formed Y-m-d date is saved as-is.
+	 */
+	public function test_valid_date_is_saved(): void {
+		$_POST['edmm_meeting_date'] = '2024-03-15';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '2024-03-15', get_post_meta( $this->post_id, 'edmm_meeting_date', true ) );
+	}
+
+	/**
+	 * A date that doesn't parse as real Y-m-d (e.g. month 13) is
+	 * rejected rather than saved.
+	 */
+	public function test_invalid_date_is_not_saved(): void {
+		$_POST['edmm_meeting_date'] = '2024-13-45';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '', get_post_meta( $this->post_id, 'edmm_meeting_date', true ) );
+	}
+
+	/**
+	 * A date string that isn't in Y-m-d format at all is rejected, not
+	 * reformatted or partially accepted.
+	 */
+	public function test_wrong_format_date_is_not_saved(): void {
+		$_POST['edmm_meeting_date'] = '03/15/2024';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '', get_post_meta( $this->post_id, 'edmm_meeting_date', true ) );
+	}
+
+	/**
+	 * The agenda URL is run through esc_url_raw() before saving.
+	 */
+	public function test_agenda_url_is_sanitized(): void {
+		$_POST['edmm_meeting_agenda_url'] = 'https://example.com/agenda.pdf"><script>alert(1)</script>';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$saved = get_post_meta( $this->post_id, 'edmm_meeting_agenda_url', true );
+		$this->assertStringNotContainsString( '<script>', $saved );
+	}
+
+	/**
+	 * The minutes URL is run through esc_url_raw() before saving.
+	 */
+	public function test_minutes_url_is_sanitized(): void {
+		$_POST['edmm_meeting_minutes_url'] = 'javascript:alert(1)';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$saved = get_post_meta( $this->post_id, 'edmm_meeting_minutes_url', true );
+		$this->assertStringNotContainsString( 'javascript:', $saved );
+	}
+
+	/**
+	 * The "not held" checkbox saves '1' when present in $_POST.
+	 */
+	public function test_not_held_checkbox_checked_saves_1(): void {
+		$_POST['edmm_meeting_not_held'] = '1';
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '1', get_post_meta( $this->post_id, 'edmm_meeting_not_held', true ) );
+	}
+
+	/**
+	 * The "not held" checkbox saves an empty string when absent from
+	 * $_POST, since unchecked checkboxes aren't submitted at all.
+	 */
+	public function test_not_held_checkbox_unchecked_saves_empty_string(): void {
+		// Deliberately not setting edmm_meeting_not_held in $_POST.
+		$this->meta_box->save_meta( $this->post_id );
+
+		$this->assertSame( '', get_post_meta( $this->post_id, 'edmm_meeting_not_held', true ) );
+	}
+
+	/**
+	 * The edmm_save_meeting_meta action fires after a successful save,
+	 * so Pro plugin can save its own additional meta in the same request.
+	 */
+	public function test_save_meeting_meta_action_fires_on_success(): void {
+		$fired_with_post_id = null;
+		$callback            = static function ( int $post_id ) use ( &$fired_with_post_id ): void {
+			$fired_with_post_id = $post_id;
+		};
+		add_action( 'edmm_save_meeting_meta', $callback );
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		remove_action( 'edmm_save_meeting_meta', $callback );
+
+		$this->assertSame( $this->post_id, $fired_with_post_id );
+	}
+
+	/**
+	 * The action does not fire when the nonce is missing/invalid, since
+	 * the method returns early before reaching it.
+	 */
+	public function test_save_meeting_meta_action_does_not_fire_without_valid_nonce(): void {
+		$_POST = []; // No nonce at all.
+
+		$fired    = false;
+		$callback = static function () use ( &$fired ): void {
+			$fired = true;
+		};
+		add_action( 'edmm_save_meeting_meta', $callback );
+
+		$this->meta_box->save_meta( $this->post_id );
+
+		remove_action( 'edmm_save_meeting_meta', $callback );
+
+		$this->assertFalse( $fired );
+	}
+}

--- a/tests/phpunit/MetaBoxSaveMetaTest.php
+++ b/tests/phpunit/MetaBoxSaveMetaTest.php
@@ -83,11 +83,19 @@ class MetaBoxSaveMetaTest extends TestCase {
 	/**
 	 * A valid nonce but a user without edit_post capability for this
 	 * post is rejected.
+	 *
+	 * The nonce must be generated for the same user whose capability is
+	 * under test (a subscriber, who can't edit this post) - reusing the
+	 * editor's nonce from set_up() while switching to a different user
+	 * would fail wp_verify_nonce() first, meaning the capability check
+	 * this test claims to cover would never actually run.
 	 */
 	public function test_user_without_capability_saves_nothing(): void {
-		wp_set_current_user( 0 ); // Logged out - no capabilities at all.
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
 
-		$_POST['edmm_meeting_date'] = '2024-03-15';
+		$_POST['edmm_meeting_meta_nonce'] = wp_create_nonce( 'edmm_save_meeting_meta' );
+		$_POST['edmm_meeting_date']       = '2024-03-15';
 
 		$this->meta_box->save_meta( $this->post_id );
 
@@ -133,24 +141,26 @@ class MetaBoxSaveMetaTest extends TestCase {
 	 * The agenda URL is run through esc_url_raw() before saving.
 	 */
 	public function test_agenda_url_is_sanitized(): void {
-		$_POST['edmm_meeting_agenda_url'] = 'https://example.com/agenda.pdf"><script>alert(1)</script>';
+		$input                            = 'https://example.com/agenda.pdf"><script>alert(1)</script>';
+		$_POST['edmm_meeting_agenda_url'] = $input;
 
 		$this->meta_box->save_meta( $this->post_id );
 
 		$saved = get_post_meta( $this->post_id, 'edmm_meeting_agenda_url', true );
-		$this->assertStringNotContainsString( '<script>', $saved );
+		$this->assertSame( esc_url_raw( $input ), $saved );
 	}
 
 	/**
 	 * The minutes URL is run through esc_url_raw() before saving.
 	 */
 	public function test_minutes_url_is_sanitized(): void {
-		$_POST['edmm_meeting_minutes_url'] = 'javascript:alert(1)';
+		$input                             = 'javascript:alert(1)';
+		$_POST['edmm_meeting_minutes_url'] = $input;
 
 		$this->meta_box->save_meta( $this->post_id );
 
 		$saved = get_post_meta( $this->post_id, 'edmm_meeting_minutes_url', true );
-		$this->assertStringNotContainsString( 'javascript:', $saved );
+		$this->assertSame( esc_url_raw( $input ), $saved );
 	}
 
 	/**

--- a/tests/phpunit/PluginBehaviorTest.php
+++ b/tests/phpunit/PluginBehaviorTest.php
@@ -74,6 +74,18 @@ class PluginBehaviorTest extends TestCase {
 	}
 
 	/**
+	 * When edmm_settings exists but doesn't contain the requested key,
+	 * it still falls back to the DEFAULTS constant - this is a
+	 * different path than "no option at all" (array key miss on an
+	 * existing array, vs. get_option()'s own default kicking in).
+	 */
+	public function test_get_setting_falls_back_to_defaults_when_option_exists_without_key(): void {
+		update_option( 'edmm_settings', [ 'some_other_setting' => 'irrelevant' ] );
+
+		$this->assertSame( 0, Plugin::get_setting( 'delete_on_uninstall' ) );
+	}
+
+	/**
 	 * A stored value takes priority over both the caller-supplied
 	 * default and the DEFAULTS constant.
 	 */

--- a/tests/phpunit/PluginBehaviorTest.php
+++ b/tests/phpunit/PluginBehaviorTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Tests for Plugin's behavior beyond the bootstrap smoke test.
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\Plugin;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers Plugin::get_instance() singleton behavior, get_setting()'s
+ * fallback chain (stored option -> caller-supplied default ->
+ * DEFAULTS constant), and register_edacp_filters() (the Accessibility
+ * Checker Pro integration point).
+ */
+class PluginBehaviorTest extends TestCase {
+
+	/**
+	 * Deletes the edmm_settings option before/after each test so
+	 * get_setting() tests start from a known, empty state.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( 'edmm_settings' );
+	}
+
+	/**
+	 * Tears down by deleting the option again.
+	 */
+	public function tear_down(): void {
+		delete_option( 'edmm_settings' );
+		parent::tear_down();
+	}
+
+	/**
+	 * get_instance() always returns the same instance.
+	 */
+	public function test_get_instance_returns_singleton(): void {
+		$this->assertSame( Plugin::get_instance(), Plugin::get_instance() );
+	}
+
+	/**
+	 * A value present in the stored edmm_settings option is returned.
+	 */
+	public function test_get_setting_returns_stored_value(): void {
+		update_option( 'edmm_settings', [ 'delete_on_uninstall' => 1 ] );
+
+		$this->assertSame( 1, Plugin::get_setting( 'delete_on_uninstall' ) );
+	}
+
+	/**
+	 * With no stored option and no key in DEFAULTS, an explicit
+	 * caller-supplied default is returned.
+	 */
+	public function test_get_setting_returns_caller_default_for_unknown_key(): void {
+		$this->assertSame( 'fallback', Plugin::get_setting( 'not_a_real_setting', 'fallback' ) );
+	}
+
+	/**
+	 * With no stored option and no caller-supplied default, a key that
+	 * exists in the DEFAULTS constant falls back to it.
+	 */
+	public function test_get_setting_falls_back_to_defaults_constant(): void {
+		$this->assertSame( 0, Plugin::get_setting( 'delete_on_uninstall' ) );
+	}
+
+	/**
+	 * With no stored option, no caller default, and no matching
+	 * DEFAULTS key, null is returned rather than throwing.
+	 */
+	public function test_get_setting_returns_null_for_completely_unknown_key(): void {
+		$this->assertNull( Plugin::get_setting( 'not_a_real_setting' ) );
+	}
+
+	/**
+	 * A stored value takes priority over both the caller-supplied
+	 * default and the DEFAULTS constant.
+	 */
+	public function test_get_setting_stored_value_takes_priority_over_default(): void {
+		update_option( 'edmm_settings', [ 'delete_on_uninstall' => 1 ] );
+
+		$this->assertSame( 1, Plugin::get_setting( 'delete_on_uninstall', 0 ) );
+	}
+
+	/**
+	 * register_edacp_filters() adds both meeting-minutes link filters to
+	 * the list Accessibility Checker Pro consumes, without disturbing
+	 * any filters already present.
+	 */
+	public function test_register_edacp_filters_adds_expected_filter_names(): void {
+		$plugin  = Plugin::get_instance();
+		$result  = $plugin->register_edacp_filters( [ 'existing_filter' ] );
+
+		$this->assertContains( 'existing_filter', $result );
+		$this->assertContains( 'edmm_meeting_minutes_link', $result );
+		$this->assertContains( 'edmm_meeting_agenda_link', $result );
+	}
+
+	/**
+	 * edmm_loaded already fired during the normal plugins_loaded
+	 * bootstrap sequence, since Plugin::boot() runs there - this is
+	 * documented as the Pro plugin's sole entry point, so it must have
+	 * actually fired by the time any test runs.
+	 */
+	public function test_edmm_loaded_action_fired_during_bootstrap(): void {
+		$this->assertGreaterThanOrEqual( 1, did_action( 'edmm_loaded' ) );
+	}
+}

--- a/tests/phpunit/SettingsPageSanitizeSettingsTest.php
+++ b/tests/phpunit/SettingsPageSanitizeSettingsTest.php
@@ -31,12 +31,31 @@ class SettingsPageSanitizeSettingsTest extends TestCase {
 
 	/**
 	 * When the checkbox key is present in the input, it's normalized to
-	 * integer 1 regardless of the submitted value.
+	 * integer 1 regardless of the submitted value - the code only
+	 * checks isset(), not the value itself.
+	 *
+	 * @dataProvider provide_present_checkbox_values
+	 * @param mixed $value The submitted value for the present key.
 	 */
-	public function test_present_checkbox_normalizes_to_1(): void {
-		$result = $this->settings_page->sanitize_settings( [ 'delete_on_uninstall' => 'on' ] );
+	public function test_present_checkbox_normalizes_to_1( $value ): void {
+		$result = $this->settings_page->sanitize_settings( [ 'delete_on_uninstall' => $value ] );
 
 		$this->assertSame( 1, $result['delete_on_uninstall'] );
+	}
+
+	/**
+	 * Data provider of "present" values isset() considers set.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function provide_present_checkbox_values(): array {
+		return [
+			'checkbox on value' => [ 'on' ],
+			'string zero'       => [ '0' ],
+			'empty string'      => [ '' ],
+			'boolean false'     => [ false ],
+			'integer zero'      => [ 0 ],
+		];
 	}
 
 	/**

--- a/tests/phpunit/SettingsPageSanitizeSettingsTest.php
+++ b/tests/phpunit/SettingsPageSanitizeSettingsTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Tests for SettingsPage::sanitize_settings().
+ *
+ * @package EqualizeDigital\MeetingMinutes
+ */
+
+use EqualizeDigital\MeetingMinutes\Admin\SettingsPage;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the Settings API sanitize_callback used when saving the
+ * plugin's persistent settings form.
+ */
+class SettingsPageSanitizeSettingsTest extends TestCase {
+
+	/**
+	 * The SettingsPage instance under test.
+	 *
+	 * @var SettingsPage
+	 */
+	private SettingsPage $settings_page;
+
+	/**
+	 * Sets up a fresh instance for each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->settings_page = new SettingsPage();
+	}
+
+	/**
+	 * When the checkbox key is present in the input, it's normalized to
+	 * integer 1 regardless of the submitted value.
+	 */
+	public function test_present_checkbox_normalizes_to_1(): void {
+		$result = $this->settings_page->sanitize_settings( [ 'delete_on_uninstall' => 'on' ] );
+
+		$this->assertSame( 1, $result['delete_on_uninstall'] );
+	}
+
+	/**
+	 * When the checkbox key is absent (unchecked checkboxes aren't
+	 * submitted at all), it's normalized to integer 0.
+	 */
+	public function test_absent_checkbox_normalizes_to_0(): void {
+		$result = $this->settings_page->sanitize_settings( [] );
+
+		$this->assertSame( 0, $result['delete_on_uninstall'] );
+	}
+
+	/**
+	 * Only the known delete_on_uninstall key is returned - any other
+	 * submitted keys are dropped rather than passed through, since this
+	 * acts as an allow-list for what can be stored in the option.
+	 */
+	public function test_unknown_input_keys_are_dropped(): void {
+		$result = $this->settings_page->sanitize_settings(
+			[
+				'delete_on_uninstall' => '1',
+				'unexpected_key'      => 'malicious_value',
+			]
+		);
+
+		$this->assertSame( [ 'delete_on_uninstall' => 1 ], $result );
+	}
+}


### PR DESCRIPTION
## Summary
Continues the test-coverage effort from PR #10 into the remaining classes that had zero coverage: `MetaBox`, `Plugin`, `PostType\MeetingMinutes`, and `SettingsPage`.

Started today at 0% coverage; combined with PR #10 (REST endpoint + shortcode) this puts the plugin well past the 20% target - this branch alone covers 17.4% of lines project-wide (measuring in isolation from PR #10's classes, which show 0% here since this branch was cut from `main` before that PR merged; the two are complementary, not overlapping).

- **`MetaBox::save_meta()`** - the plugin's only direct-`$_POST` write path, and the highest-value target: nonce presence/validity gating, capability gating, Y-m-d date validation (accepts/rejects malformed and wrong-format dates), `esc_url_raw` sanitization on both URL fields, the not-held checkbox's present/absent behavior, and the `edmm_save_meeting_meta` action firing only on success.
- **`MetaBox::register_post_meta()`** - registered schema (correct `sanitize_callback` per field), and the `auth_callback` closure directly exercised across the scenarios relevant to the `$object_id = 0` regression fixed in PR #9/#10: post-specific allow/deny, falling back to `edit_posts` when `object_id` is 0, and denying a logged-out user regardless.
- **`MetaBox::add_meta_box()`** - the `edmm_use_native_meta_boxes` filter (documented Pro extension point to fully replace the meta box UI).
- **`Plugin`** - `get_instance()` singleton behavior, `get_setting()`'s full fallback chain (stored option -> caller default -> `DEFAULTS` constant -> null), `register_edacp_filters()` (the Accessibility Checker Pro integration point), and confirms `edmm_loaded` fires during bootstrap (documented as Pro's sole entry point).
- **`PostType\MeetingMinutes`** - locks in the documented `public => false` / `show_in_rest => true` combination as a regression guard, and verifies the `edmm_cpt_args` filter both receives the registration args and can actually change registered CPT behavior.
- **`SettingsPage::sanitize_settings()`** - checkbox normalization and confirms unknown input keys are dropped (it acts as an allow-list for the stored option).

## Test plan
- [x] `docker compose exec phpunit vendor/bin/phpunit` - 39 tests, 54 assertions, all passing
- [x] `composer lint` / `composer check-cs` pass
- [x] The CPT-args-mutating test restores normal registration in a `finally` block so a failed assertion can't leak state into other tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration test coverage for the meeting minutes custom post type registration, including documented default arguments and filter-driven overrides.
  * Verified meta box registration (default and filter-suppressed) and correct registration of all post meta keys.
  * Confirmed meta sanitization and authorization behavior, including nonce validation, date format handling, URL sanitization, and checkbox persistence rules.
  * Expanded plugin behavior tests for singleton behavior, settings fallback logic, filter registration augmentation, and bootstrap completion.
  * Added settings page sanitization tests to normalize `delete_on_uninstall` and drop unknown inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->