### PR TITLE
feat: add edmm_meeting_formatted_date filter for date display overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Keep this list current when adding or removing hooks — it's the primary refere
 | `edmm_rest_query_args` | filter | `REST/MeetingMinutesEndpoint.php` | Modify the `WP_Query` args before querying meeting minutes. |
 | `edmm_meeting_agenda_link` / `edmm_meeting_minutes_link` | filter | `REST/MeetingMinutesEndpoint.php` | Override the built `<a>` markup for agenda/minutes links (used by Accessibility Checker Pro integration). |
 | `edmm_meeting_row_data` | filter | `REST/MeetingMinutesEndpoint.php` | Add/override fields on a single meeting's REST row data. |
+| `edmm_meeting_formatted_date` | filter | `REST/MeetingMinutesEndpoint.php` | Override the computed date display string before it's used in the date cell and in the agenda/minutes link aria-labels (used by Pro's per-meeting date display override — sort order is unaffected, it's driven by the raw `edmm_meeting_date` value). |
 | `edmm_rest_response` | filter | `REST/MeetingMinutesEndpoint.php` | Modify the full REST response before it's returned. |
 | `edmm_enqueue_assets` | action | `Shortcode/MeetingMinutesShortcode.php` | Fires after core CSS/JS enqueue — Pro enqueues its own assets here. |
 | `edmm_shortcode_atts` | filter | `Shortcode/MeetingMinutesShortcode.php` | Add new recognized shortcode attributes. |

--- a/includes/REST/MeetingMinutesEndpoint.php
+++ b/includes/REST/MeetingMinutesEndpoint.php
@@ -242,6 +242,22 @@ class MeetingMinutesEndpoint {
 			? esc_html( $date_object->format( $meeting_not_held ? $not_held_date_format : $held_date_format ) )
 			: '<span class="sr-text screen-reader-text">' . esc_html__( 'Date not available', 'edmm' ) . '</span>';
 
+		/**
+		 * Filters the formatted date string before it's used in the visible date
+		 * cell and in the agenda/minutes link aria-labels below. Pro plugin uses
+		 * this to substitute a per-meeting text override (e.g. "March Special",
+		 * "TBD") for the computed date, honored whenever set regardless of
+		 * held/not-held status. Sort order is unaffected — it's driven by the
+		 * raw edmm_meeting_date value, not this display string.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $formatted_date   The computed/escaped date display string.
+		 * @param int    $post_id          The post ID.
+		 * @param bool   $meeting_not_held Whether the meeting is marked not held.
+		 */
+		$formatted_date = apply_filters( 'edmm_meeting_formatted_date', $formatted_date, $post_id, $meeting_not_held );
+
 		$agenda_item = $meeting_agenda_url
 			? apply_filters(
 				'edmm_meeting_agenda_link',

--- a/includes/REST/MeetingMinutesEndpoint.php
+++ b/includes/REST/MeetingMinutesEndpoint.php
@@ -256,7 +256,8 @@ class MeetingMinutesEndpoint {
 		 * @param int    $post_id          The post ID.
 		 * @param bool   $meeting_not_held Whether the meeting is marked not held.
 		 */
-		$formatted_date = apply_filters( 'edmm_meeting_formatted_date', $formatted_date, $post_id, $meeting_not_held );
+		$filtered_date  = apply_filters( 'edmm_meeting_formatted_date', $formatted_date, $post_id, $meeting_not_held );
+		$formatted_date = is_string( $filtered_date ) ? wp_kses_post( $filtered_date ) : $formatted_date;
 
 		$agenda_item = $meeting_agenda_url
 			? apply_filters(


### PR DESCRIPTION
## Summary
- Adds a new `edmm_meeting_formatted_date` filter in `MeetingMinutesEndpoint::build_meeting_row()`, applied immediately after the meeting date is computed and before it's used in the agenda/minutes link `aria-label`s.
- Enables the Pro plugin to substitute a per-meeting date display override (e.g. "March Special", "TBD") everywhere the date renders — not just the visible date cell — while leaving sort order untouched (still driven by the raw `edmm_meeting_date` meta value).
- Documents the new hook in `CLAUDE.md`'s extension points table.

This is additive only — no existing hook signatures changed, so no entry needed in `docs/HOOK-CONTRACT-CHANGES.md`.

Companion PR in the Pro repo adds the actual override field/UI/CSV support that consumes this filter.

## Test plan
- [x] `composer lint` — no syntax errors
- [x] `composer check-cs` — 0 errors/warnings
- [ ] Manual: confirm a meeting with no override still displays the normal formatted date
- [ ] Manual (with Pro active): confirm a meeting with the override set shows the override text in the date cell and in the agenda/minutes link aria-labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new meeting date formatting hook (`edmm_meeting_formatted_date`) to customize the displayed meeting date and the agenda/minutes link aria-label text (display-only; sorting remains based on the existing meeting date).
* **Documentation**
  * Updated developer documentation to include the new `edmm_meeting_formatted_date` filter and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->