### PR TITLE
refactor: swap require_once class loading for a Composer PSR-4 autoloader

### DIFF
--- a/.claude/skills/package-plugins/SKILL.md
+++ b/.claude/skills/package-plugins/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: package-plugins
+description: Build and zip the free (equalize-digital-meeting-minutes) and Pro (meeting-minutes-pro) plugins into deployable dist/ zips with the correct contents. Use when asked to package, zip, release, or deploy either plugin.
+---
+
+# Package the free and/or Pro plugin into a deploy zip
+
+Both repos ship as manually-built zips in each repo's gitignored `dist/`. There is no npm `package` script (yet). The zip contents below were verified against the known-good zips built 2026-07-07 (post Composer-autoloader switch, PRO-1187).
+
+## Critical rules
+
+1. **Always run the JS build first.** Built output is gitignored in both repos (`assets/build/` in free, `build/` in Pro). A zip missing it installs fine but renders an empty table / broken block editor with a 404'd script.
+2. **Always run `composer install --no-dev --optimize-autoloader` before staging, and a plain `composer install` again after zipping.** Both plugins bootstrap via a Composer PSR-4 autoloader (`vendor/autoload.php`) — a zip without it fatal-errors on activation. Neither plugin has a runtime Composer dependency (only `php` itself in `require`; everything else is `require-dev` tooling), so `--no-dev` leaves `vendor/` containing only Composer's own autoloader machinery (`vendor/autoload.php` + `vendor/composer/*.php`, no third-party library code) — safe to ship wholesale. The restore step afterward matters: skipping it silently drops phpcs/phpunit/etc. from the working tree for the rest of the session.
+3. The zip must contain a single top-level directory named exactly like the plugin slug (`equalize-digital-meeting-minutes/` or `meeting-minutes-pro/`) — WordPress derives the install path from it.
+4. Never include: `node_modules/`, `tests/`, `docs/`, `dist/`, `scripts/`, dotfiles (`.git*`, `.eslintrc`, `.husky/`, `.editorconfig`), `composer.json`, `composer.lock`, `package*.json`, `phpunit*`, `phpcs.xml`, `webpack.config.js`, `docker-compose.yml`. (`vendor/` is now a required exception to the general "no dev-tooling directories" rule — see above.)
+5. In Pro, `src/js/admin/` and `src/js/front-end/` are **plain-file enqueues and MUST ship**; `src/js/block/` is bundler source and must NOT ship. In free, no `src/` ships at all (everything is bundled).
+
+## Free plugin
+
+```bash
+cd <free-repo>
+npm run build   # -> assets/build/meeting-minutes.js
+composer install --no-dev --optimize-autoloader
+mkdir -p dist && rm -f dist/equalize-digital-meeting-minutes.zip
+STAGE=$(mktemp -d)/equalize-digital-meeting-minutes && mkdir -p "$STAGE"
+cp -r --parents \
+  equalize-digital-meeting-minutes.php uninstall.php readme.txt \
+  includes partials languages vendor \
+  assets/build assets/css \
+  "$STAGE"/
+( cd "$(dirname "$STAGE")" && zip -r "$OLDPWD/dist/equalize-digital-meeting-minutes.zip" equalize-digital-meeting-minutes )
+composer install   # restore dev tooling (phpcs/phpunit/etc.) - don't skip this
+```
+
+Expected manifest (verify with `unzip -l`):
+`equalize-digital-meeting-minutes.php`, `uninstall.php`, `readme.txt`, `languages/edmm.pot`, `partials/{meta-box,settings-page}.php`, `assets/build/meeting-minutes.js`, `assets/css/meeting-minutes.css`, `vendor/autoload.php`, `vendor/composer/*.php`, `includes/Plugin.php`, `includes/{Admin/{MetaBox,SettingsPage},PostType/MeetingMinutes,REST/MeetingMinutesEndpoint,Shortcode/{FieldRegistry,MeetingMinutesShortcode}}.php`
+
+## Pro plugin
+
+```bash
+cd <pro-repo>   # ../meeting-minutes-pro relative to the free repo
+npm run build   # -> build/index.js + build/index.asset.php
+composer install --no-dev --optimize-autoloader
+mkdir -p dist && rm -f dist/meeting-minutes-pro.zip
+STAGE=$(mktemp -d)/meeting-minutes-pro && mkdir -p "$STAGE"
+cp -r --parents \
+  meeting-minutes-pro.php block.json readme.txt \
+  includes partials build vendor \
+  assets/css \
+  src/js/admin src/js/front-end \
+  "$STAGE"/
+( cd "$(dirname "$STAGE")" && zip -r "$OLDPWD/dist/meeting-minutes-pro.zip" meeting-minutes-pro )
+composer install   # restore dev tooling (phpcs/phpunit/etc.) - don't skip this
+```
+
+Expected manifest:
+`meeting-minutes-pro.php`, `block.json`, `readme.txt`, `build/{index.js,index.asset.php}`, `assets/css/pro-meta.css`, `vendor/autoload.php`, `vendor/composer/*.php`, `partials/{pro-meta-fields,csv-import-page,license-section,block-editor-preview}.php`, `includes/{Plugin,License/LicenseManager,Admin/ProMetaFields,PostType/MeetingCategory,Block/MeetingMinutesBlock,Import/CsvImporter}.php`, `src/js/{admin/proMeta,front-end/proColumns,front-end/yearTimelineTemplate}.js`
+
+Note: `partials/shortcode-builder-fields.php` no longer exists (deleted in the shortcode-field-registry refactor, PR equalize-digital-meeting-minutes#19 / meeting-minutes-pro#11) — don't re-add it if an old checklist still references it.
+
+## After building
+
+- Sanity-check both manifests with `unzip -l dist/*.zip` — compare against the lists above; investigate any new file before shipping it (new includes/partials belong in the zip; new dev files don't). Confirm `vendor/` in the zip contains *only* `autoload.php` + `composer/` — if any other top-level package directory shows up under `vendor/`, the `--no-dev` install didn't take (re-run it) or a real runtime dependency was added to `composer.json` and this doc needs a rethink (a runtime dep would mean actual third-party library code ships too, not just the autoloader).
+- If a directory was added to either plugin since 2026-07-07, update the `cp` list here AND the expected manifest.
+- Deploy order on a site: free plugin first, then Pro (Pro no-ops with an admin notice if free is inactive).

--- a/.claude/skills/package-plugins/SKILL.md
+++ b/.claude/skills/package-plugins/SKILL.md
@@ -10,10 +10,11 @@ Both repos ship as manually-built zips in each repo's gitignored `dist/`. There 
 ## Critical rules
 
 1. **Always run the JS build first.** Built output is gitignored in both repos (`assets/build/` in free, `build/` in Pro). A zip missing it installs fine but renders an empty table / broken block editor with a 404'd script.
-2. **Always run `composer install --no-dev --optimize-autoloader` before staging, and a plain `composer install` again after zipping.** Both plugins bootstrap via a Composer PSR-4 autoloader (`vendor/autoload.php`) — a zip without it fatal-errors on activation. Neither plugin has a runtime Composer dependency (only `php` itself in `require`; everything else is `require-dev` tooling), so `--no-dev` leaves `vendor/` containing only Composer's own autoloader machinery (`vendor/autoload.php` + `vendor/composer/*.php`, no third-party library code) — safe to ship wholesale. The restore step afterward matters: skipping it silently drops phpcs/phpunit/etc. from the working tree for the rest of the session.
+2. **Always run `composer install --no-dev --optimize-autoloader` before staging, and a plain `composer install` again after zipping.** Both plugins bootstrap via a Composer PSR-4 autoloader (`vendor/autoload.php`) — a zip without it fatal-errors on activation. Neither plugin has a runtime Composer dependency (only `php` itself in `require`; everything else is `require-dev` tooling), so `--no-dev` leaves `vendor/` containing only Composer's own autoloader machinery (`vendor/autoload.php` + `vendor/composer/*`, no third-party library code) — safe to ship wholesale. The restore step afterward matters: skipping it silently drops phpcs/phpunit/etc. from the working tree for the rest of the session.
 3. The zip must contain a single top-level directory named exactly like the plugin slug (`equalize-digital-meeting-minutes/` or `meeting-minutes-pro/`) — WordPress derives the install path from it.
 4. Never include: `node_modules/`, `tests/`, `docs/`, `dist/`, `scripts/`, dotfiles (`.git*`, `.eslintrc`, `.husky/`, `.editorconfig`), `composer.json`, `composer.lock`, `package*.json`, `phpunit*`, `phpcs.xml`, `webpack.config.js`, `docker-compose.yml`. (`vendor/` is now a required exception to the general "no dev-tooling directories" rule — see above.)
 5. In Pro, `src/js/admin/` and `src/js/front-end/` are **plain-file enqueues and MUST ship**; `src/js/block/` is bundler source and must NOT ship. In free, no `src/` ships at all (everything is bundled).
+6. **Run each plugin's whole bash block as a single script**, not line-by-line — `$STAGE` (and `$OLDPWD` inside the zip subshell) are shell variables/state that don't persist across separate command invocations.
 
 ## Free plugin
 
@@ -29,6 +30,7 @@ cp -r \
   "$STAGE"/
 cp -r assets/build assets/css "$STAGE/assets/"
 ( cd "$(dirname "$STAGE")" && zip -r "$OLDPWD/dist/equalize-digital-meeting-minutes.zip" equalize-digital-meeting-minutes )
+rm -rf "$(dirname "$STAGE")"
 composer install   # restore dev tooling (phpcs/phpunit/etc.) - don't skip this
 ```
 
@@ -50,6 +52,7 @@ cp -r \
 cp -r assets/css "$STAGE/assets/"
 cp -r src/js/admin src/js/front-end "$STAGE/src/js/"
 ( cd "$(dirname "$STAGE")" && zip -r "$OLDPWD/dist/meeting-minutes-pro.zip" meeting-minutes-pro )
+rm -rf "$(dirname "$STAGE")"
 composer install   # restore dev tooling (phpcs/phpunit/etc.) - don't skip this
 ```
 

--- a/.claude/skills/package-plugins/SKILL.md
+++ b/.claude/skills/package-plugins/SKILL.md
@@ -22,12 +22,12 @@ cd <free-repo>
 npm run build   # -> assets/build/meeting-minutes.js
 composer install --no-dev --optimize-autoloader
 mkdir -p dist && rm -f dist/equalize-digital-meeting-minutes.zip
-STAGE=$(mktemp -d)/equalize-digital-meeting-minutes && mkdir -p "$STAGE"
-cp -r --parents \
+STAGE=$(mktemp -d)/equalize-digital-meeting-minutes && mkdir -p "$STAGE/assets"
+cp -r \
   equalize-digital-meeting-minutes.php uninstall.php readme.txt \
   includes partials languages vendor \
-  assets/build assets/css \
   "$STAGE"/
+cp -r assets/build assets/css "$STAGE/assets/"
 ( cd "$(dirname "$STAGE")" && zip -r "$OLDPWD/dist/equalize-digital-meeting-minutes.zip" equalize-digital-meeting-minutes )
 composer install   # restore dev tooling (phpcs/phpunit/etc.) - don't skip this
 ```
@@ -42,13 +42,13 @@ cd <pro-repo>   # ../meeting-minutes-pro relative to the free repo
 npm run build   # -> build/index.js + build/index.asset.php
 composer install --no-dev --optimize-autoloader
 mkdir -p dist && rm -f dist/meeting-minutes-pro.zip
-STAGE=$(mktemp -d)/meeting-minutes-pro && mkdir -p "$STAGE"
-cp -r --parents \
+STAGE=$(mktemp -d)/meeting-minutes-pro && mkdir -p "$STAGE/assets" "$STAGE/src/js"
+cp -r \
   meeting-minutes-pro.php block.json readme.txt \
   includes partials build vendor \
-  assets/css \
-  src/js/admin src/js/front-end \
   "$STAGE"/
+cp -r assets/css "$STAGE/assets/"
+cp -r src/js/admin src/js/front-end "$STAGE/src/js/"
 ( cd "$(dirname "$STAGE")" && zip -r "$OLDPWD/dist/meeting-minutes-pro.zip" meeting-minutes-pro )
 composer install   # restore dev tooling (phpcs/phpunit/etc.) - don't skip this
 ```

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
     "require": {
         "php": ">=7.4"
     },
+    "autoload": {
+        "psr-4": {
+            "EqualizeDigital\\MeetingMinutes\\": "includes/"
+        }
+    },
     "require-dev": {
         "automattic/vipwpcs": "^3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -38,8 +38,7 @@ if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
 	return;
 }
 
-// Plugin constants.
-define( 'EDMM_VERSION', '1.0.0' );
+// Plugin constants needed by the autoloader guard below.
 define( 'EDMM_FILE', __FILE__ );
 define( 'EDMM_DIR', plugin_dir_path( __FILE__ ) );
 define( 'EDMM_URL', plugin_dir_url( __FILE__ ) );
@@ -58,6 +57,13 @@ if ( ! file_exists( EDMM_DIR . 'vendor/autoload.php' ) ) {
 	return;
 }
 require_once EDMM_DIR . 'vendor/autoload.php';
+
+// EDMM_VERSION is defined only once the plugin can actually boot - the
+// Pro plugin's own bootstrap checks defined( 'EDMM_VERSION' ) as its
+// "is free active" signal, so defining it any earlier (e.g. alongside
+// the other constants above) would make Pro think free is active even
+// when the autoloader guard above just bailed.
+define( 'EDMM_VERSION', '1.0.0' );
 
 // Boot the plugin.
 add_action(

--- a/equalize-digital-meeting-minutes.php
+++ b/equalize-digital-meeting-minutes.php
@@ -44,14 +44,20 @@ define( 'EDMM_FILE', __FILE__ );
 define( 'EDMM_DIR', plugin_dir_path( __FILE__ ) );
 define( 'EDMM_URL', plugin_dir_url( __FILE__ ) );
 
-// Load all classes.
-require_once EDMM_DIR . 'includes/Shortcode/FieldRegistry.php';
-require_once EDMM_DIR . 'includes/PostType/MeetingMinutes.php';
-require_once EDMM_DIR . 'includes/Admin/MetaBox.php';
-require_once EDMM_DIR . 'includes/Admin/SettingsPage.php';
-require_once EDMM_DIR . 'includes/REST/MeetingMinutesEndpoint.php';
-require_once EDMM_DIR . 'includes/Shortcode/MeetingMinutesShortcode.php';
-require_once EDMM_DIR . 'includes/Plugin.php';
+// Autoloads all EqualizeDigital\MeetingMinutes\* classes under includes/
+// (PSR-4, see composer.json) - no per-class require_once line needed.
+if ( ! file_exists( EDMM_DIR . 'vendor/autoload.php' ) ) {
+	add_action(
+		'admin_notices',
+		function () {
+			echo '<div class="notice notice-error"><p>'
+			. esc_html__( 'Equalize Digital Meeting Minutes is missing its autoloader. Reinstall from a released zip, or run `composer install` if developing from source.', 'edmm' )
+			. '</p></div>';
+		}
+	);
+	return;
+}
+require_once EDMM_DIR . 'vendor/autoload.php';
 
 // Boot the plugin.
 add_action(


### PR DESCRIPTION
## Summary
PRO-1187. Replaces the six manually-listed `require_once` lines in the bootstrap with Composer's PSR-4 autoloader — new classes under `includes/` no longer need a matching bootstrap line to be added by hand.

- `composer.json`: added `"autoload": {"psr-4": {"EqualizeDigital\\MeetingMinutes\\": "includes/"}}` (the namespace already matched the directory layout 1:1, no restructuring needed).
- `equalize-digital-meeting-minutes.php`: the `require_once` block is now a single guarded `require_once EDMM_DIR . 'vendor/autoload.php'` — guarded the same way the existing PHP-version check is (admin notice + bail if missing, not a raw fatal).
- **Packaging** (`.claude/skills/package-plugins/SKILL.md`): `vendor/` was previously hard-excluded from the release zip, which would fatal every production site once activated with a Composer-only bootstrap. Fixed: neither plugin has any *runtime* Composer dependency (only `php` itself), so `composer install --no-dev --optimize-autoloader` leaves `vendor/` containing only Composer's own autoloader machinery — 84KB, no third-party library code — safe to ship. Added that step (+ a restore step afterward so dev tooling doesn't silently vanish from the working tree) to both plugins' packaging procedure, verified against a real staged zip (see test plan).
- Also fixed two manifest entries in that same skill file that had drifted from the shortcode-field-registry work (PR #19): missing `FieldRegistry.php`, and a stale reference to the now-deleted `shortcode-builder-fields.php`.
- Companion PR incoming for `meeting-minutes-pro` (same branch name) — Pro has the identical `require_once` pattern.

## Test plan
- [x] `npm run test:php:run` — all 84 tests pass unchanged under autoloading
- [x] `npm run lint:php` — clean
- [x] Staged a real zip per the updated packaging steps (`composer install --no-dev -o`, build, `cp`, zip) and `unzip -l`'d it — `vendor/` contains exactly `autoload.php` + `vendor/composer/*` (12 files, no dev packages), manifest matches what's documented; ran `composer install` again afterward to confirm dev tooling (phpcs/phpunit) is restored
- [ ] Manual: fresh plugin activation on a real site to confirm the missing-autoloader admin notice path doesn't fatal (reviewed the guard logic, but no live WP install in this environment to click through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added packaging guidance for creating deployable plugin archives, including build steps, file inclusion rules, and validation checks.
  * Added automatic class loading support so the plugin can load its code more reliably from a standard project structure.

* **Bug Fixes**
  * Improved startup behavior when required build files are missing by showing a clear admin notice instead of failing silently.
  * Adjusted version handling to avoid incorrect activation signals during incomplete installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->