### PR TITLE
feat: rename custom post type to "Board Meetings" (edbs_meetings)

### DIFF
--- a/includes/Admin/MetaBox.php
+++ b/includes/Admin/MetaBox.php
@@ -27,7 +27,7 @@ class MetaBox {
 	public function register(): void {
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ] );
-		add_action( 'save_post_edbs_boardscribe', [ $this, 'save_meta' ] );
+		add_action( 'save_post_edbs_meetings', [ $this, 'save_meta' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 	}
 
@@ -45,7 +45,7 @@ class MetaBox {
 		}
 
 		$screen = get_current_screen();
-		if ( ! $screen || 'edbs_boardscribe' !== $screen->post_type ) {
+		if ( ! $screen || 'edbs_meetings' !== $screen->post_type ) {
 			return;
 		}
 
@@ -115,7 +115,7 @@ JS;
 		];
 
 		register_post_meta(
-			'edbs_boardscribe',
+			'edbs_meetings',
 			'edbs_meeting_date',
 			array_merge(
 				$common,
@@ -128,7 +128,7 @@ JS;
 		);
 
 		register_post_meta(
-			'edbs_boardscribe',
+			'edbs_meetings',
 			'edbs_agenda_url',
 			array_merge(
 				$common,
@@ -141,7 +141,7 @@ JS;
 		);
 
 		register_post_meta(
-			'edbs_boardscribe',
+			'edbs_meetings',
 			'edbs_minutes_url',
 			array_merge(
 				$common,
@@ -154,7 +154,7 @@ JS;
 		);
 
 		register_post_meta(
-			'edbs_boardscribe',
+			'edbs_meetings',
 			'edbs_meeting_not_held',
 			array_merge(
 				$common,
@@ -191,7 +191,7 @@ JS;
 			'edbs_meeting_details',
 			__( 'Meeting Details', 'boardscribe' ),
 			[ $this, 'render_meta_box' ],
-			'edbs_boardscribe',
+			'edbs_meetings',
 			'normal',
 			'high'
 		);

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -49,7 +49,7 @@ class SettingsPage {
 	 */
 	public function add_builder_submenu_page(): void {
 		add_submenu_page(
-			'edit.php?post_type=edbs_boardscribe',
+			'edit.php?post_type=edbs_meetings',
 			__( 'Shortcode Builder', 'boardscribe' ),
 			__( 'Shortcode Builder', 'boardscribe' ),
 			'manage_options',
@@ -67,7 +67,7 @@ class SettingsPage {
 	 */
 	public function add_submenu_page(): void {
 		add_submenu_page(
-			'edit.php?post_type=edbs_boardscribe',
+			'edit.php?post_type=edbs_meetings',
 			__( 'BoardScribe Settings', 'boardscribe' ),
 			__( 'Settings', 'boardscribe' ),
 			'manage_options',
@@ -126,7 +126,7 @@ class SettingsPage {
 	 * @return void
 	 */
 	public function enqueue_builder_script( string $hook ): void {
-		if ( 'edbs_boardscribe_page_edbs-shortcode-builder' !== $hook ) {
+		if ( 'edbs_meetings_page_edbs-shortcode-builder' !== $hook ) {
 			return;
 		}
 

--- a/includes/Block/BoardScribeBlock.php
+++ b/includes/Block/BoardScribeBlock.php
@@ -224,7 +224,7 @@ class BoardScribeBlock {
 		$posts_per_page     = min( $posts_per_page, max( 1, $max_rows ) );
 
 		$query_args = [
-			'post_type'      => 'edbs_boardscribe',
+			'post_type'      => 'edbs_meetings',
 			'posts_per_page' => $posts_per_page,
 			'post_status'    => 'publish',
 			'orderby'        => 'meta_value',

--- a/includes/PostType/BoardScribeCPT.php
+++ b/includes/PostType/BoardScribeCPT.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Registers and manages the edbs_boardscribe custom post type.
+ * Registers and manages the edbs_meetings custom post type.
  */
 class BoardScribeCPT {
 
@@ -28,7 +28,7 @@ class BoardScribeCPT {
 	}
 
 	/**
-	 * Registers the edbs_boardscribe custom post type.
+	 * Registers the edbs_meetings custom post type.
 	 *
 	 * @since x.x.x
 	 *
@@ -36,14 +36,16 @@ class BoardScribeCPT {
 	 */
 	public function register_post_type(): void {
 		$labels = [
-			'name'           => _x( 'BoardScribe Meetings', 'Post Type General Name', 'boardscribe' ),
-			'singular_name'  => _x( 'BoardScribe Meeting', 'Post Type Singular Name', 'boardscribe' ),
-			'menu_name'      => __( 'BoardScribe', 'boardscribe' ),
-			'name_admin_bar' => __( 'BoardScribe Meeting', 'boardscribe' ),
+			'name'           => _x( 'Board Meetings', 'Post Type General Name', 'boardscribe' ),
+			'singular_name'  => _x( 'Board Meeting', 'Post Type Singular Name', 'boardscribe' ),
+			'menu_name'      => __( 'Board Meetings', 'boardscribe' ),
+			'name_admin_bar' => __( 'Board Meeting', 'boardscribe' ),
+			'add_new'        => __( 'Add Meeting', 'boardscribe' ),
+			'add_new_item'   => __( 'Add New Meeting', 'boardscribe' ),
 		];
 
 		$args = [
-			'label'         => __( 'BoardScribe Meeting', 'boardscribe' ),
+			'label'         => __( 'Board Meeting', 'boardscribe' ),
 			'labels'        => $labels,
 			'supports'      => [ 'title' ],
 			// No public single/archive templates — meetings are only ever
@@ -52,7 +54,7 @@ class BoardScribeCPT {
 			'rewrite'       => false,
 			'has_archive'   => false,
 			'show_ui'       => true,
-			// Intentionally still exposes the default /wp/v2/edbs_boardscribe
+			// Intentionally still exposes the default /wp/v2/edbs_meetings
 			// REST route (needed for the block editor meta box UI); this is fine
 			// since published meetings are meant to be public records.
 			'show_in_rest'  => true,
@@ -61,7 +63,7 @@ class BoardScribeCPT {
 		];
 
 		/**
-		 * Filters the edbs_boardscribe CPT registration args. Pro plugin uses
+		 * Filters the edbs_meetings CPT registration args. Pro plugin uses
 		 * this to enable public/rewrite/archive support or a custom capability_type.
 		 *
 		 * @since x.x.x
@@ -78,7 +80,7 @@ class BoardScribeCPT {
 		 */
 		do_action( 'edbs_before_register_cpt' );
 
-		register_post_type( 'edbs_boardscribe', $args );
+		register_post_type( 'edbs_meetings', $args );
 
 		/**
 		 * Fires after the BoardScribe CPT is registered. Register taxonomies

--- a/includes/REST/BoardScribeEndpoint.php
+++ b/includes/REST/BoardScribeEndpoint.php
@@ -141,7 +141,7 @@ class BoardScribeEndpoint {
 		}
 
 		$args = [
-			'post_type'      => 'edbs_boardscribe',
+			'post_type'      => 'edbs_meetings',
 			'post_status'    => 'publish',
 			'posts_per_page' => $posts_per_page,
 			'paged'          => $page,

--- a/tests/phpunit/BoardScribeCptTest.php
+++ b/tests/phpunit/BoardScribeCptTest.php
@@ -16,10 +16,10 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
 class BoardScribeCptTest extends TestCase {
 
 	/**
-	 * The edbs_boardscribe post type is registered.
+	 * The edbs_meetings post type is registered.
 	 */
 	public function test_cpt_is_registered(): void {
-		$this->assertTrue( post_type_exists( 'edbs_boardscribe' ) );
+		$this->assertTrue( post_type_exists( 'edbs_meetings' ) );
 	}
 
 	/**
@@ -27,7 +27,7 @@ class BoardScribeCptTest extends TestCase {
 	 * defaults (public => false but show_in_rest => true).
 	 */
 	public function test_cpt_has_documented_default_args(): void {
-		$post_type_object = get_post_type_object( 'edbs_boardscribe' );
+		$post_type_object = get_post_type_object( 'edbs_meetings' );
 
 		$this->assertFalse( $post_type_object->public );
 		$this->assertTrue( $post_type_object->show_in_rest );
@@ -48,7 +48,7 @@ class BoardScribeCptTest extends TestCase {
 		};
 		add_filter( 'edbs_cpt_args', $callback );
 
-		unregister_post_type( 'edbs_boardscribe' );
+		unregister_post_type( 'edbs_meetings' );
 		( new BoardScribeCPT() )->register_post_type();
 
 		remove_filter( 'edbs_cpt_args', $callback );
@@ -70,16 +70,16 @@ class BoardScribeCptTest extends TestCase {
 		add_filter( 'edbs_cpt_args', $callback );
 
 		try {
-			unregister_post_type( 'edbs_boardscribe' );
+			unregister_post_type( 'edbs_meetings' );
 			( new BoardScribeCPT() )->register_post_type();
 
-			$post_type_object = get_post_type_object( 'edbs_boardscribe' );
+			$post_type_object = get_post_type_object( 'edbs_meetings' );
 			$this->assertTrue( $post_type_object->public );
 		} finally {
 			// Restore the CPT to its normal registration for subsequent
 			// tests, even if the assertion above failed.
 			remove_filter( 'edbs_cpt_args', $callback );
-			unregister_post_type( 'edbs_boardscribe' );
+			unregister_post_type( 'edbs_meetings' );
 			( new BoardScribeCPT() )->register_post_type();
 		}
 	}

--- a/tests/phpunit/BoardScribeEndpointBuildRowTest.php
+++ b/tests/phpunit/BoardScribeEndpointBuildRowTest.php
@@ -53,7 +53,7 @@ class BoardScribeEndpointBuildRowTest extends TestCase {
 	private function create_meeting( array $meta = [], array $post_args = [] ): int {
 		$post_id = self::factory()->post->create(
 			array_merge(
-				[ 'post_type' => 'edbs_boardscribe' ],
+				[ 'post_type' => 'edbs_meetings' ],
 				$post_args
 			)
 		);

--- a/tests/phpunit/BoardScribeEndpointRestTest.php
+++ b/tests/phpunit/BoardScribeEndpointRestTest.php
@@ -36,7 +36,7 @@ class BoardScribeEndpointRestTest extends TestCase {
 	 * @return int The created post ID.
 	 */
 	private function create_meeting( array $meta = [] ): int {
-		$post_id = self::factory()->post->create( [ 'post_type' => 'edbs_boardscribe' ] );
+		$post_id = self::factory()->post->create( [ 'post_type' => 'edbs_meetings' ] );
 
 		foreach ( $meta as $key => $value ) {
 			update_post_meta( $post_id, $key, $value );

--- a/tests/phpunit/MetaBoxAddMetaBoxTest.php
+++ b/tests/phpunit/MetaBoxAddMetaBoxTest.php
@@ -22,7 +22,7 @@ class MetaBoxAddMetaBoxTest extends TestCase {
 	public function set_up(): void {
 		parent::set_up();
 		global $wp_meta_boxes;
-		unset( $wp_meta_boxes['edbs_boardscribe'] );
+		unset( $wp_meta_boxes['edbs_meetings'] );
 	}
 
 	/**
@@ -32,7 +32,7 @@ class MetaBoxAddMetaBoxTest extends TestCase {
 		( new MetaBox() )->add_meta_box();
 
 		global $wp_meta_boxes;
-		$this->assertArrayHasKey( 'edbs_meeting_details', $wp_meta_boxes['edbs_boardscribe']['normal']['high'] );
+		$this->assertArrayHasKey( 'edbs_meeting_details', $wp_meta_boxes['edbs_meetings']['normal']['high'] );
 	}
 
 	/**
@@ -47,6 +47,6 @@ class MetaBoxAddMetaBoxTest extends TestCase {
 		remove_filter( 'edbs_use_native_meta_boxes', '__return_false' );
 
 		global $wp_meta_boxes;
-		$this->assertArrayNotHasKey( 'edbs_boardscribe', (array) $wp_meta_boxes );
+		$this->assertArrayNotHasKey( 'edbs_meetings', (array) $wp_meta_boxes );
 	}
 }

--- a/tests/phpunit/MetaBoxRegisterMetaTest.php
+++ b/tests/phpunit/MetaBoxRegisterMetaTest.php
@@ -36,7 +36,7 @@ class MetaBoxRegisterMetaTest extends TestCase {
 	 */
 	private function get_meta_args( string $meta_key ): array {
 		global $wp_meta_keys;
-		return $wp_meta_keys['post']['edbs_boardscribe'][ $meta_key ];
+		return $wp_meta_keys['post']['edbs_meetings'][ $meta_key ];
 	}
 
 	/**
@@ -45,7 +45,7 @@ class MetaBoxRegisterMetaTest extends TestCase {
 	 */
 	public function test_all_meta_keys_are_registered(): void {
 		global $wp_meta_keys;
-		$keys = array_keys( $wp_meta_keys['post']['edbs_boardscribe'] );
+		$keys = array_keys( $wp_meta_keys['post']['edbs_meetings'] );
 
 		foreach ( [ 'edbs_meeting_date', 'edbs_agenda_url', 'edbs_minutes_url', 'edbs_meeting_not_held' ] as $expected_key ) {
 			$this->assertContains( $expected_key, $keys );
@@ -75,7 +75,7 @@ class MetaBoxRegisterMetaTest extends TestCase {
 	 * even if they could edit posts of this type in general.
 	 */
 	public function test_auth_callback_denies_user_without_post_specific_capability(): void {
-		$post_id       = self::factory()->post->create( [ 'post_type' => 'edbs_boardscribe' ] );
+		$post_id       = self::factory()->post->create( [ 'post_type' => 'edbs_meetings' ] );
 		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
 		wp_set_current_user( $subscriber_id );
 
@@ -91,7 +91,7 @@ class MetaBoxRegisterMetaTest extends TestCase {
 	 * With a real post ID, a user who can edit that post is allowed.
 	 */
 	public function test_auth_callback_allows_user_with_post_specific_capability(): void {
-		$post_id   = self::factory()->post->create( [ 'post_type' => 'edbs_boardscribe' ] );
+		$post_id   = self::factory()->post->create( [ 'post_type' => 'edbs_meetings' ] );
 		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
 		wp_set_current_user( $editor_id );
 

--- a/tests/phpunit/MetaBoxSaveMetaTest.php
+++ b/tests/phpunit/MetaBoxSaveMetaTest.php
@@ -38,7 +38,7 @@ class MetaBoxSaveMetaTest extends TestCase {
 		parent::set_up();
 
 		$this->meta_box = new MetaBox();
-		$this->post_id  = self::factory()->post->create( [ 'post_type' => 'edbs_boardscribe' ] );
+		$this->post_id  = self::factory()->post->create( [ 'post_type' => 'edbs_meetings' ] );
 
 		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
 		wp_set_current_user( $editor_id );

--- a/tests/phpunit/SettingsPageEnqueueBuilderScriptTest.php
+++ b/tests/phpunit/SettingsPageEnqueueBuilderScriptTest.php
@@ -19,7 +19,7 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  */
 class SettingsPageEnqueueBuilderScriptTest extends TestCase {
 
-	const BUILDER_HOOK = 'edbs_boardscribe_page_edbs-shortcode-builder';
+	const BUILDER_HOOK = 'edbs_meetings_page_edbs-shortcode-builder';
 
 	/**
 	 * The SettingsPage instance under test.

--- a/uninstall.php
+++ b/uninstall.php
@@ -20,17 +20,17 @@ if ( empty( $edbs_settings['delete_on_uninstall'] ) ) {
 }
 
 // Delete all BoardScribe meeting posts and their associated meta.
-$edbs_boardscribe_post_ids = get_posts(
+$edbs_meeting_post_ids = get_posts(
 	[
-		'post_type'      => 'edbs_boardscribe',
+		'post_type'      => 'edbs_meetings',
 		'post_status'    => 'any',
 		'posts_per_page' => -1,
 		'fields'         => 'ids',
 	]
 );
 
-foreach ( $edbs_boardscribe_post_ids as $edbs_boardscribe_post_id ) {
-	wp_delete_post( $edbs_boardscribe_post_id, true );
+foreach ( $edbs_meeting_post_ids as $edbs_meeting_post_id ) {
+	wp_delete_post( $edbs_meeting_post_id, true );
 }
 
 // Delete plugin settings.


### PR DESCRIPTION
## Summary

Renames the meeting custom post type to **Board Meetings** and changes the internal post-type key from `edbs_boardscribe` to `edbs_meetings`.

## Changes

- **Labels** — CPT `name`/`singular_name`/`menu_name`/`name_admin_bar` now read "Board Meeting(s)"; adds `add_new` → "Add Meeting" and `add_new_item` → "Add New Meeting" (these previously fell back to WordPress's default "Add New Post").
- **Post-type key** `edbs_boardscribe` → `edbs_meetings`, propagated to everywhere it's derived:
  - Meta box registration + the dynamic `save_post_{type}` hook (`Admin/MetaBox.php`)
  - REST endpoint query (`REST/BoardScribeEndpoint.php`)
  - Block editor preview query (`Block/BoardScribeBlock.php`)
  - Settings/Shortcode Builder submenu parent **and** its derived `{post_type}_page_…` admin page hook (`Admin/SettingsPage.php`)
  - Uninstall cleanup query (`uninstall.php`)
  - PHPUnit tests

## Intentionally unchanged

The `[edbs_boardscribe]` **shortcode tag** and the `equalize-digital/boardscribe` **block name** are left as-is — both are stored in existing post content and must never change.

## ⚠️ Data migration

The post-type key lives in the `wp_posts.post_type` column. On any site with existing meetings, this rename orphans that data unless a migration runs. Assumed safe here as pre-release (versions are still `x.x.x` placeholders) — flag if that's not the case and I'll add an upgrade routine.

## Paired change

Requires the matching Pro PR (`equalizedigital/boardscribe-pro` branch `rename-cpt-to-edbs-meetings`), which updates Pro's bindings to the same key.

Refs #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StaFhhvvrFYX5aAhhQM9kc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Board meetings are now managed under the “Board Meetings” content type throughout the admin interface.
  * Meeting details, REST data, editor previews, and shortcode builder pages now use the updated meetings destination.
  * Uninstall cleanup now removes saved board meeting records when enabled.

* **Tests**
  * Updated automated coverage to validate meeting management, metadata, REST responses, admin screens, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->