### PR TITLE
fix: correct Meeting Date field description

### DIFF
--- a/partials/meta-box.php
+++ b/partials/meta-box.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					required
 					class="regular-text"
 				/>
-				<p class="description"><?php esc_html_e( 'Required. Format: YYYY-MM-DD', 'boardscribe' ); ?></p>
+				<p class="description"><?php esc_html_e( 'Required. Select the date the meeting was or will be held.', 'boardscribe' ); ?></p>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Summary

The Meeting Date field is a native `<input type="date">`, so the browser renders a locale-formatted date picker (e.g. `07/22/2026` in the US). Users never type `YYYY-MM-DD` — that's only the underlying value format — so the "Required. Format: YYYY-MM-DD" hint was misleading.

Replaced it with guidance on what date to select:

> Required. Select the date the meeting was or will be held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StaFhhvvrFYX5aAhhQM9kc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the meeting date field help text to clarify that users should select the date the meeting was or will be held.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->