### PR TITLE
feat: retitle General tab section to "General Settings"

### DIFF
--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -167,9 +167,9 @@ class SettingsPage {
 		);
 
 		add_settings_section(
-			'edbs_advanced_section',
-			__( 'Advanced', 'boardscribe' ),
-			[ $this, 'render_advanced_section' ],
+			'edbs_general_section',
+			__( 'General Settings', 'boardscribe' ),
+			[ $this, 'render_general_section' ],
 			self::PAGE_SLUG
 		);
 
@@ -178,7 +178,7 @@ class SettingsPage {
 			__( 'Delete Data on Uninstall', 'boardscribe' ),
 			[ $this, 'render_delete_on_uninstall' ],
 			self::PAGE_SLUG,
-			'edbs_advanced_section'
+			'edbs_general_section'
 		);
 	}
 
@@ -240,14 +240,14 @@ class SettingsPage {
 	}
 
 	/**
-	 * Renders the Advanced section intro copy.
+	 * Renders the General section intro copy.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return void
 	 */
-	public function render_advanced_section(): void {
-		echo '<p>' . esc_html__( 'Advanced options for BoardScribe.', 'boardscribe' ) . '</p>';
+	public function render_general_section(): void {
+		echo '<p>' . esc_html__( 'Configure general settings for the BoardScribe plugin.', 'boardscribe' ) . '</p>';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Replaces the General tab's "Advanced" section heading and its "Advanced options for BoardScribe." description with, at the top of the tab:

> **General Settings**
> Configure general settings for the BoardScribe plugin.

## Changes
- `add_settings_section()` title → "General Settings"; section id renamed `edbs_advanced_section` → `edbs_general_section` (updated the `add_settings_field()` reference too).
- `render_advanced_section()` → `render_general_section()`, outputting the new description.

No stale references remain; PHPCS + syntax pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StaFhhvvrFYX5aAhhQM9kc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reorganized the settings page by moving persistent settings, including the uninstall option, from the Advanced section to General.
  * Updated the General tab’s introductory content to reflect the revised settings layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->