### PR TITLE
style: remove accent stripes from settings panel header

### DIFF
--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -150,27 +150,6 @@ body.edbs_meeting_page_edbs-settings {
 	overflow: hidden;
 }
 
-/* Double accent stripe on the right edge (plum + blue). */
-.edbs-settings-panel-header::before {
-	content: "";
-	position: absolute;
-	background-color: var(--edbs-blue);
-	width: 5px;
-	bottom: 0;
-	top: 0;
-	right: 0;
-}
-
-.edbs-settings-panel-header::after {
-	content: "";
-	position: absolute;
-	background-color: var(--edbs-plum);
-	width: 5px;
-	bottom: 0;
-	top: 0;
-	right: 5px;
-}
-
 .edbs-settings-panel-header .dashicons {
 	font-size: 23px;
 	width: 23px;


### PR DESCRIPTION
## Summary

Removes the plum/blue double accent stripe on the right edge of the settings panel header (the `.edbs-settings-panel-header::before` / `::after` pseudo-elements). The navy header background is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StaFhhvvrFYX5aAhhQM9kc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the decorative double stripe from the settings panel header.
  * Retained the header’s existing layout, background, sizing, and overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->