### PR TITLE
style: set settings sidebar width to 225px

### DIFF
--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -49,8 +49,8 @@ body.edbs_meeting_page_edbs-settings {
 @media (min-width: 783px) {
 
 	.edbs-settings-header {
-		width: 265px;
-		min-width: 265px;
+		width: 225px;
+		min-width: 225px;
 		margin-bottom: 25px;
 	}
 }


### PR DESCRIPTION
## Summary

Narrows the settings page sidebar (`.edbs-settings-header`) from 265px to 225px (width + min-width, at the ≥783px breakpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StaFhhvvrFYX5aAhhQM9kc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the settings sidebar header layout on larger screens.
  * Reduced the header width to create a more compact interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->