### PR TITLE
fix: default meeting date display to a US long-date format

### DIFF
--- a/includes/Block/BoardScribeBlock.php
+++ b/includes/Block/BoardScribeBlock.php
@@ -250,8 +250,8 @@ class BoardScribeBlock {
 
 		$endpoint    = new BoardScribeEndpoint();
 		$format_args = [
-			'held_date_format'     => $attributes['heldDateFormat'] ?? 'Y/m/d',
-			'not_held_date_format' => $attributes['notHeldDateFormat'] ?? 'Y/m',
+			'held_date_format'     => $attributes['heldDateFormat'] ?? 'F j, Y',
+			'not_held_date_format' => $attributes['notHeldDateFormat'] ?? 'F Y',
 			'agenda_link_label'    => $attributes['agendaLinkLabel'] ?? '',
 			'minutes_link_label'   => $attributes['minutesLinkLabel'] ?? '',
 		];

--- a/includes/REST/BoardScribeEndpoint.php
+++ b/includes/REST/BoardScribeEndpoint.php
@@ -250,8 +250,8 @@ class BoardScribeEndpoint {
 	 * @return array
 	 */
 	public function build_meeting_row( int $post_id, array $format_args, ?\WP_REST_Request $request = null ): array {
-		$held_date_format     = $format_args['held_date_format'] ?? 'Y/m/d';
-		$not_held_date_format = $format_args['not_held_date_format'] ?? 'Y/m';
+		$held_date_format     = $format_args['held_date_format'] ?? 'F j, Y';
+		$not_held_date_format = $format_args['not_held_date_format'] ?? 'F Y';
 		$agenda_link_label    = ! empty( $format_args['agenda_link_label'] ) ? $format_args['agenda_link_label'] : __( 'View Agenda', 'boardscribe' );
 		$minutes_link_label   = ! empty( $format_args['minutes_link_label'] ) ? $format_args['minutes_link_label'] : __( 'View Minutes', 'boardscribe' );
 

--- a/includes/Shortcode/FieldRegistry.php
+++ b/includes/Shortcode/FieldRegistry.php
@@ -132,10 +132,10 @@ class FieldRegistry {
 					'type'              => self::TYPE_TEXT,
 					'group'             => 'general',
 					'label'             => __( 'Held Date Format', 'boardscribe' ),
-					'default'           => 'Y/m/d',
+					'default'           => 'F j, Y',
 					'description'       => __( 'PHP date() format. See php.net/manual/en/datetime.format.php for the full reference.', 'boardscribe' ),
 					'sanitize_callback' => static function ( $value ) {
-						return self::sanitize_date_format( $value, 'Y/m/d' );
+						return self::sanitize_date_format( $value, 'F j, Y' );
 					},
 					'validate_callback' => [ BoardScribeEndpoint::class, 'validate_date_format' ],
 					'rest_arg'          => true,
@@ -145,9 +145,9 @@ class FieldRegistry {
 					'type'              => self::TYPE_TEXT,
 					'group'             => 'general',
 					'label'             => __( 'Not Held Date Format', 'boardscribe' ),
-					'default'           => 'Y/m',
+					'default'           => 'F Y',
 					'sanitize_callback' => static function ( $value ) {
-						return self::sanitize_date_format( $value, 'Y/m' );
+						return self::sanitize_date_format( $value, 'F Y' );
 					},
 					'validate_callback' => [ BoardScribeEndpoint::class, 'validate_date_format' ],
 					'rest_arg'          => true,

--- a/src/js/defaults/request.js
+++ b/src/js/defaults/request.js
@@ -20,8 +20,8 @@ import { apiBaseUrl } from '../config';
 export function defaultBuildRequestUrl( instanceCfg, page ) {
 	const url = new URL( apiBaseUrl, window.location.origin );
 	url.searchParams.set( 'included_years', instanceCfg.includedYears || '' );
-	url.searchParams.set( 'held_date_format', instanceCfg.heldDateFormat || 'Y/m/d' );
-	url.searchParams.set( 'not_held_date_format', instanceCfg.notHeldDateFormat || 'Y/m' );
+	url.searchParams.set( 'held_date_format', instanceCfg.heldDateFormat || 'F j, Y' );
+	url.searchParams.set( 'not_held_date_format', instanceCfg.notHeldDateFormat || 'F Y' );
 	url.searchParams.set( 'posts_per_page', instanceCfg.postsPerPage || 20 );
 	url.searchParams.set( 'agenda_link_label', instanceCfg.agendaLinkLabel || '' );
 	url.searchParams.set( 'minutes_link_label', instanceCfg.minutesLinkLabel || '' );

--- a/tests/phpunit/BoardScribeEndpointValidateDateFormatTest.php
+++ b/tests/phpunit/BoardScribeEndpointValidateDateFormatTest.php
@@ -33,8 +33,8 @@ class BoardScribeEndpointValidateDateFormatTest extends TestCase {
 	 */
 	public function provide_valid_formats(): array {
 		return [
-			'default held format'     => [ 'Y/m/d' ],
-			'default not-held format' => [ 'Y/m' ],
+			'default held format'     => [ 'F j, Y' ],
+			'default not-held format' => [ 'F Y' ],
 			'with time and dashes'    => [ 'Y-m-d H:i:s' ],
 		];
 	}

--- a/tests/phpunit/BoardScribeShortcodeTest.php
+++ b/tests/phpunit/BoardScribeShortcodeTest.php
@@ -90,7 +90,7 @@ class BoardScribeShortcodeTest extends TestCase {
 		$html   = $this->shortcode->render( [ 'held_date_format' => '\\<\\s\\c\\r\\i\\p\\t\\>' ] );
 		$config = $this->get_instance_config( $html );
 
-		$this->assertSame( 'Y/m/d', $config['heldDateFormat'] );
+		$this->assertSame( 'F j, Y', $config['heldDateFormat'] );
 	}
 
 	/**
@@ -100,7 +100,7 @@ class BoardScribeShortcodeTest extends TestCase {
 		$html   = $this->shortcode->render( [ 'not_held_date_format' => '<script>' ] );
 		$config = $this->get_instance_config( $html );
 
-		$this->assertSame( 'Y/m', $config['notHeldDateFormat'] );
+		$this->assertSame( 'F Y', $config['notHeldDateFormat'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The Held / Not Held date format fields defaulted to `Y/m/d` (2026/07/22) and `Y/m` (2026/07) — an ISO-looking format that reads oddly for the plugin's US audience and, notably, **did not match the admin meta box**, which already formats the held date using the site's `date_format` option (falling back to `F j, Y`).

This aligns the frontend defaults with the meta box:

- **Held Date Format:** `Y/m/d` → `F j, Y` ("July 22, 2026")
- **Not Held Date Format:** `Y/m` → `F Y` ("July 2026")

## Why not "inherit the site `date_format` option"?

That was considered but rejected: the Not Held field is deliberately month/year-only (a cancelled meeting shows just the month), which the site `date_format` (always day-inclusive) can't express, and an empty-means-inherit default hurts discoverability in the builder/block UI and adds cross-repo contract surface. A concrete, meta-box-matching default is the simpler, safer fix.

## Scope

Changed across the four in-sync locations plus tests:

- `includes/Shortcode/FieldRegistry.php` — field defaults + sanitize fallbacks (source of truth for shortcode/builder/block/REST)
- `includes/REST/BoardScribeEndpoint.php` — `build_meeting_row()` fallback
- `includes/Block/BoardScribeBlock.php` — block render fallback
- `src/js/defaults/request.js` — frontend fetch fallback
- Two PHPUnit tests asserting the fallback defaults

## Safety

- Both new formats pass `validate_date_format()` (comma/space are allowed literals), so **existing saved values and custom overrides are unaffected** — only the default shifts.
- Existing instances that explicitly saved the old format keep it; only new instances and those left on the default pick up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated default meeting date displays to use readable formats, such as “January 15, 2025” for held meetings and “January 2025” for meetings not yet held.
  * Applied the updated formats consistently across editor previews, rendered content, and generated requests.

* **Bug Fixes**
  * Corrected fallback date formatting when custom date formats are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->