### PR TITLE
fix: shortcode builder accessibility pass (headings, date format, table semantics, contrast)

### DIFF
--- a/assets/css/boardscribe.css
+++ b/assets/css/boardscribe.css
@@ -6,13 +6,15 @@
 .edbs-pagination-button {
     padding: 5px 10px;
     border: none;
-    background-color: #007bff;
+    /* White text at ~7:1 against this shade, passing WCAG AA/AAA for
+       normal text - the previous #007bff was only ~4:1, failing AA. */
+    background-color: #0056b3;
     color: white;
     cursor: pointer;
 }
 
 .edbs-pagination-button.current {
-    background-color: #0056b3;
+    background-color: #003d80;
 }
 
 .edbs-pagination-button[disabled] {

--- a/assets/css/builder.css
+++ b/assets/css/builder.css
@@ -59,3 +59,11 @@
 .edbs-builder-app__snackbar-error {
 	background-color: #cc1818;
 }
+
+/* CardHeader isn't a heading element - the h2 inside it (see app.js/
+   preview.js, fixing #49) needs its user-agent margin/font reset so it
+   renders identically to the plain text it replaces. */
+.edbs-builder-app__card-heading {
+	margin: 0;
+	font: inherit;
+}

--- a/includes/Block/BoardScribeBlock.php
+++ b/includes/Block/BoardScribeBlock.php
@@ -281,7 +281,7 @@ class BoardScribeBlock {
 
 		$endpoint    = new BoardScribeEndpoint();
 		$format_args = [
-			'held_date_format'     => $attributes['heldDateFormat'] ?? 'F j, Y',
+			'held_date_format'     => $attributes['heldDateFormat'] ?? 'l, F j, Y',
 			'not_held_date_format' => $attributes['notHeldDateFormat'] ?? 'F Y',
 			'agenda_link_label'    => $attributes['agendaLinkLabel'] ?? '',
 			'minutes_link_label'   => $attributes['minutesLinkLabel'] ?? '',

--- a/includes/REST/BoardScribeEndpoint.php
+++ b/includes/REST/BoardScribeEndpoint.php
@@ -250,7 +250,7 @@ class BoardScribeEndpoint {
 	 * @return array
 	 */
 	public function build_meeting_row( int $post_id, array $format_args, ?\WP_REST_Request $request = null ): array {
-		$held_date_format     = $format_args['held_date_format'] ?? 'F j, Y';
+		$held_date_format     = $format_args['held_date_format'] ?? 'l, F j, Y';
 		$not_held_date_format = $format_args['not_held_date_format'] ?? 'F Y';
 		$agenda_link_label    = ! empty( $format_args['agenda_link_label'] ) ? $format_args['agenda_link_label'] : __( 'View Agenda', 'boardscribe' );
 		$minutes_link_label   = ! empty( $format_args['minutes_link_label'] ) ? $format_args['minutes_link_label'] : __( 'View Minutes', 'boardscribe' );

--- a/includes/Shortcode/FieldRegistry.php
+++ b/includes/Shortcode/FieldRegistry.php
@@ -132,10 +132,12 @@ class FieldRegistry {
 					'type'              => self::TYPE_TEXT,
 					'group'             => 'general',
 					'label'             => __( 'Held Date Format', 'boardscribe' ),
-					'default'           => 'F j, Y',
+					// Spelled-out weekday reads more reliably to screen readers
+					// than a bare numeric/abbreviated date (see boardscribe#46).
+					'default'           => 'l, F j, Y',
 					'description'       => __( 'PHP date() format. See php.net/manual/en/datetime.format.php for the full reference.', 'boardscribe' ),
 					'sanitize_callback' => static function ( $value ) {
-						return self::sanitize_date_format( $value, 'F j, Y' );
+						return self::sanitize_date_format( $value, 'l, F j, Y' );
 					},
 					'validate_callback' => [ BoardScribeEndpoint::class, 'validate_date_format' ],
 					'rest_arg'          => true,

--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,7 @@ Use the **Settings > Shortcode Builder** to generate the shortcode with your pre
 
 * `included_years` - Comma-separated years to display (e.g. `2023,2024`). Default: all years.
 * `posts_per_page` - Entries per page. Use `-1` to show all. Default: `20`.
-* `held_date_format` - PHP date format for meetings that were held. Default: `F j, Y`.
+* `held_date_format` - PHP date format for meetings that were held. Default: `l, F j, Y`.
 * `not_held_date_format` - PHP date format for meetings not held. Default: `F Y`.
 * `hide_title` - Set to `true` to hide the Title column. Default: `false`.
 * `hide_date` - Set to `true` to hide the Date column. Default: `false`.

--- a/src/js/builder/app.js
+++ b/src/js/builder/app.js
@@ -202,7 +202,9 @@ export function BuilderApp( { fields } ) {
 
 			<div className="edbs-builder-app__result">
 				<Card>
-					<CardHeader>{ __( 'Your Shortcode', 'boardscribe' ) }</CardHeader>
+					<CardHeader>
+						<h2 className="edbs-builder-app__card-heading">{ __( 'Your Shortcode', 'boardscribe' ) }</h2>
+					</CardHeader>
 					<CardBody>
 						<div className="edbs-builder-app__output-row">
 							<input

--- a/src/js/builder/preview.js
+++ b/src/js/builder/preview.js
@@ -78,7 +78,9 @@ export function Preview( { fields, values } ) {
 
 	return (
 		<Card className="edbs-builder-preview">
-			<CardHeader>{ __( 'Preview', 'boardscribe' ) }</CardHeader>
+			<CardHeader>
+				<h2 className="edbs-builder-app__card-heading">{ __( 'Preview', 'boardscribe' ) }</h2>
+			</CardHeader>
 			<CardBody>
 				{ /* Keyed on the config so each change remounts a clean copy of
 				     the exact wrapper markup BoardScribeShortcode::render()

--- a/src/js/defaults/request.js
+++ b/src/js/defaults/request.js
@@ -20,7 +20,7 @@ import { apiBaseUrl } from '../config';
 export function defaultBuildRequestUrl( instanceCfg, page ) {
 	const url = new URL( apiBaseUrl, window.location.origin );
 	url.searchParams.set( 'included_years', instanceCfg.includedYears || '' );
-	url.searchParams.set( 'held_date_format', instanceCfg.heldDateFormat || 'F j, Y' );
+	url.searchParams.set( 'held_date_format', instanceCfg.heldDateFormat || 'l, F j, Y' );
 	url.searchParams.set( 'not_held_date_format', instanceCfg.notHeldDateFormat || 'F Y' );
 	url.searchParams.set( 'posts_per_page', instanceCfg.postsPerPage || 20 );
 	url.searchParams.set( 'agenda_link_label', instanceCfg.agendaLinkLabel || '' );

--- a/src/js/templates/table.js
+++ b/src/js/templates/table.js
@@ -41,20 +41,27 @@ export function buildTableHtml( meetings, instanceCfg ) {
 	const tableClass = escapeAttribute( cfg.tableClass || '' );
 	const templateClass = escapeAttribute( 'edbs-template-' + ( cfg.resolvedTemplate || 'table' ) );
 	const equalColumnsClass = cfg.equalColumns ? 'edbs-equal-columns' : '';
-	let table = '<table tabindex="0" class="edbs-boardscribe-table ' + templateClass + ' ' + equalColumnsClass + ' ' + tableClass + '">' +
-		'<thead class="desktop"><tr>';
+	// Explicit table/row/cell roles below are belt-and-braces: the
+	// responsive stacking layout (see the max-width:768px block in
+	// boardscribe.css) overrides `display` on every one of these
+	// elements, which strips their *implicit* table semantics in some
+	// browsers (most notably Safari/VoiceOver) - explicit roles keep the
+	// table announced as a table, with header/cell relationships intact,
+	// regardless of that CSS.
+	let table = '<table tabindex="0" role="table" class="edbs-boardscribe-table ' + templateClass + ' ' + equalColumnsClass + ' ' + tableClass + '">' +
+		'<thead class="desktop" role="rowgroup"><tr role="row">';
 
 	if ( ! cfg.hideTitle ) {
-		table += '<th scope="col">' + escapeHTML( labelTitle ) + '</th>';
+		table += '<th scope="col" role="columnheader">' + escapeHTML( labelTitle ) + '</th>';
 	}
 	if ( ! cfg.hideDate ) {
-		table += '<th scope="col">' + escapeHTML( labelDate ) + '</th>';
+		table += '<th scope="col" role="columnheader">' + escapeHTML( labelDate ) + '</th>';
 	}
 	if ( ! cfg.hideAgenda ) {
-		table += '<th scope="col">' + escapeHTML( labelAgenda ) + '</th>';
+		table += '<th scope="col" role="columnheader">' + escapeHTML( labelAgenda ) + '</th>';
 	}
 	if ( ! cfg.hideMinutes ) {
-		table += '<th scope="col">' + escapeHTML( labelMinutes ) + '</th>';
+		table += '<th scope="col" role="columnheader">' + escapeHTML( labelMinutes ) + '</th>';
 	}
 
 	// hidden()/getLabel() only depend on cfg, not on any one meeting, so
@@ -75,10 +82,10 @@ export function buildTableHtml( meetings, instanceCfg ) {
 		} );
 
 	visibleExtraColumns.forEach( function( entry ) {
-		table += '<th scope="col">' + ( entry.label || '' ) + '</th>';
+		table += '<th scope="col" role="columnheader">' + ( entry.label || '' ) + '</th>';
 	} );
 
-	table += '</tr></thead><tbody>';
+	table += '</tr></thead><tbody role="rowgroup">';
 
 	// Cell content below (meeting.title, meeting.date, meeting.agenda,
 	// meeting.minutes, and any Pro-registered renderCell() output) is
@@ -91,23 +98,27 @@ export function buildTableHtml( meetings, instanceCfg ) {
 			return;
 		}
 
-		table += '<tr>';
+		table += '<tr role="row">';
 		if ( ! cfg.hideTitle ) {
-			table += '<td data-label="' + escapeAttribute( labelTitle ) + '" scope="row">' + ( meeting.title || '' ) + '</td>';
+			// role="rowheader" is the ARIA (not `scope`) way to mark a <td>
+			// as a row header - `scope` is only valid on <th> and browsers
+			// silently ignore it here, leaving the row with no accessible
+			// header at all.
+			table += '<td data-label="' + escapeAttribute( labelTitle ) + '" role="rowheader">' + ( meeting.title || '' ) + '</td>';
 		}
 		if ( ! cfg.hideDate ) {
-			table += '<td data-label="' + escapeAttribute( labelDate ) + '">' + ( meeting.date || '' ) + '</td>';
+			table += '<td data-label="' + escapeAttribute( labelDate ) + '" role="cell">' + ( meeting.date || '' ) + '</td>';
 		}
 		if ( ! cfg.hideAgenda ) {
-			table += '<td data-label="' + escapeAttribute( labelAgenda ) + '">' + ( meeting.agenda || '' ) + '</td>';
+			table += '<td data-label="' + escapeAttribute( labelAgenda ) + '" role="cell">' + ( meeting.agenda || '' ) + '</td>';
 		}
 		if ( ! cfg.hideMinutes ) {
-			table += '<td data-label="' + escapeAttribute( labelMinutes ) + '">' + ( meeting.minutes || '' ) + '</td>';
+			table += '<td data-label="' + escapeAttribute( labelMinutes ) + '" role="cell">' + ( meeting.minutes || '' ) + '</td>';
 		}
 
 		visibleExtraColumns.forEach( function( entry ) {
 			const cell = entry.col.renderCell ? entry.col.renderCell( meeting, cfg ) : ( meeting[ entry.col.key ] || '' );
-			table += '<td data-label="' + escapeAttribute( entry.label || '' ) + '">' + cell + '</td>';
+			table += '<td data-label="' + escapeAttribute( entry.label || '' ) + '" role="cell">' + cell + '</td>';
 		} );
 
 		table += '</tr>';

--- a/tests/phpunit/BoardScribeEndpointValidateDateFormatTest.php
+++ b/tests/phpunit/BoardScribeEndpointValidateDateFormatTest.php
@@ -33,7 +33,7 @@ class BoardScribeEndpointValidateDateFormatTest extends TestCase {
 	 */
 	public function provide_valid_formats(): array {
 		return [
-			'default held format'     => [ 'F j, Y' ],
+			'default held format'     => [ 'l, F j, Y' ],
 			'default not-held format' => [ 'F Y' ],
 			'with time and dashes'    => [ 'Y-m-d H:i:s' ],
 		];

--- a/tests/phpunit/BoardScribeShortcodeTest.php
+++ b/tests/phpunit/BoardScribeShortcodeTest.php
@@ -90,7 +90,7 @@ class BoardScribeShortcodeTest extends TestCase {
 		$html   = $this->shortcode->render( [ 'held_date_format' => '\\<\\s\\c\\r\\i\\p\\t\\>' ] );
 		$config = $this->get_instance_config( $html );
 
-		$this->assertSame( 'F j, Y', $config['heldDateFormat'] );
+		$this->assertSame( 'l, F j, Y', $config['heldDateFormat'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

A pass over the accessibility issues Amber flagged on the Shortcode Builder page (Settings → Shortcode Builder), plus two more I found reviewing the same table markup while in there.

- **Closes #49** — "Your Shortcode" and "Preview" were plain text inside a `CardHeader` (a styled div, not a heading). Now real `<h2>`s, visually unchanged.
- **Closes #46** — `held_date_format` default changed from `F j, Y` to `l, F j, Y` (spelled-out weekday reads more reliably to screen readers). Updated everywhere the default is duplicated (shortcode builder field, REST fallback, block attribute fallback, JS request fallback) so the builder's live preview always matches real output. `not_held_date_format` was already `F Y` - untouched.
- **Table row-header bug** — the title cell used `scope="row"` on a `<td>`; `scope` is only valid on `<th>`, so it was silently ignored and the row had no accessible header. Switched to `role="rowheader"` and added explicit `table`/`rowgroup`/`row`/`columnheader`/`cell` roles throughout, since the mobile responsive stacking layout (`display: block/flex` at ≤768px) strips *implicit* table semantics in some browsers (notably Safari/VoiceOver) regardless of the underlying element - explicit roles keep it announced as a table at every viewport width.
- **Pagination button contrast** — default (non-current) pagination buttons were white text on `#007bff`, ~4:1, failing WCAG AA's 4.5:1 for normal text. Swapped to the `#0056b3` already used for the "current" state (~7:1), and moved "current" to a darker `#003d80` (~10.6:1) so the two states stay visually distinct.

## Test plan
- [x] `composer lint` / `phpcs` clean
- [x] `npm run lint:js` clean
- [x] `npm run build` — all three webpack bundles compile
- [x] Full PHPUnit suite (95 tests / 178 assertions) passes, including two updated assertions for the new date-format default
- [ ] Manual check in wp-admin (Settings → Shortcode Builder): headings show up in a screen reader's headings list, table still announces as a table on a narrow viewport, pagination buttons read clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Meeting dates now include the day of the week by default for clearer context.
  - Improved table accessibility with explicit semantic roles for headers, rows, and cells.
- **Bug Fixes**
  - Increased pagination button contrast, including clearer styling for the current page.
  - Standardized builder card headings for consistent typography and spacing.
- **Documentation**
  - Updated shortcode documentation to reflect the new default meeting date format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->