### PR TITLE
PRO-1237: feat: allow filtering by start and end date in the block and shortcode builder

### DIFF
--- a/includes/Block/BoardScribeBlock.php
+++ b/includes/Block/BoardScribeBlock.php
@@ -265,8 +265,16 @@ class BoardScribeBlock {
 			'no_found_rows'  => true,
 		];
 
-		$start_date = (string) ( $attributes['startDate'] ?? '' );
-		$end_date   = (string) ( $attributes['endDate'] ?? '' );
+		// Resolved through the same sanitize_iso_date() the frontend
+		// shortcode path uses (via FieldRegistry::resolve_value()) rather
+		// than trusted raw - hand-edited/invalid block markup would
+		// otherwise make this preview disagree with the real query.
+		$start_date = isset( $attributes['startDate'] ) && is_string( $attributes['startDate'] )
+			? FieldRegistry::sanitize_iso_date( $attributes['startDate'] )
+			: '';
+		$end_date   = isset( $attributes['endDate'] ) && is_string( $attributes['endDate'] )
+			? FieldRegistry::sanitize_iso_date( $attributes['endDate'] )
+			: '';
 
 		// Mirrors BoardScribeEndpoint::get_meetings()'s precedence: an
 		// explicit start/end date range takes priority over includedYears

--- a/includes/Block/BoardScribeBlock.php
+++ b/includes/Block/BoardScribeBlock.php
@@ -141,6 +141,7 @@ class BoardScribeBlock {
 			FieldRegistry::TYPE_SELECT          => 'string',
 			FieldRegistry::TYPE_NUMBER          => 'number',
 			FieldRegistry::TYPE_NUMBER_WITH_ALL => 'number',
+			FieldRegistry::TYPE_DATE            => 'string',
 		];
 
 		$attributes = [];
@@ -264,7 +265,45 @@ class BoardScribeBlock {
 			'no_found_rows'  => true,
 		];
 
-		if ( ! empty( $attributes['includedYears'] ) ) {
+		$start_date = (string) ( $attributes['startDate'] ?? '' );
+		$end_date   = (string) ( $attributes['endDate'] ?? '' );
+
+		// Mirrors BoardScribeEndpoint::get_meetings()'s precedence: an
+		// explicit start/end date range takes priority over includedYears
+		// entirely, rather than being combined with it. Filtered against
+		// the edbs_meeting_date meta value (meta_query), not post_date —
+		// same field the query above already orders by, and the same
+		// field the real REST/front-end query filters against.
+		if ( '' !== $start_date || '' !== $end_date ) {
+			if ( '' !== $start_date && '' !== $end_date ) {
+				$query_args['meta_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- required to filter the editor preview by meeting date range.
+					[
+						'key'     => 'edbs_meeting_date',
+						'value'   => [ $start_date, $end_date ],
+						'compare' => 'BETWEEN',
+						'type'    => 'DATE',
+					],
+				];
+			} elseif ( '' !== $start_date ) {
+				$query_args['meta_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- required to filter the editor preview by meeting date range.
+					[
+						'key'     => 'edbs_meeting_date',
+						'value'   => $start_date,
+						'compare' => '>=',
+						'type'    => 'DATE',
+					],
+				];
+			} else {
+				$query_args['meta_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- required to filter the editor preview by meeting date range.
+					[
+						'key'     => 'edbs_meeting_date',
+						'value'   => $end_date,
+						'compare' => '<=',
+						'type'    => 'DATE',
+					],
+				];
+			}
+		} elseif ( ! empty( $attributes['includedYears'] ) ) {
 			$years = array_filter( array_map( 'trim', explode( ',', $attributes['includedYears'] ) ) );
 			if ( $years ) {
 				$query_args['date_query']             = array_map(

--- a/includes/REST/BoardScribeEndpoint.php
+++ b/includes/REST/BoardScribeEndpoint.php
@@ -109,6 +109,8 @@ class BoardScribeEndpoint {
 		$held_date_format     = $request->get_param( 'held_date_format' );
 		$not_held_date_format = $request->get_param( 'not_held_date_format' );
 		$included_years       = $request->get_param( 'included_years' );
+		$start_date           = $request->get_param( 'start_date' );
+		$end_date             = $request->get_param( 'end_date' );
 		$agenda_link_label    = $request->get_param( 'agenda_link_label' ) ? $request->get_param( 'agenda_link_label' ) : __( 'View Agenda', 'boardscribe' );
 		$minutes_link_label   = $request->get_param( 'minutes_link_label' ) ? $request->get_param( 'minutes_link_label' ) : __( 'View Minutes', 'boardscribe' );
 
@@ -157,7 +159,35 @@ class BoardScribeEndpoint {
 			],
 		];
 
-		if ( ! empty( $included_years ) ) {
+		if ( ! empty( $start_date ) || ! empty( $end_date ) ) {
+			// start_date/end_date support arbitrary ranges (e.g. a
+			// July-to-June fiscal year) that included_years can't express,
+			// so they take priority over it entirely rather than being
+			// combined — a caller sending both almost certainly means the
+			// explicit range, not an intersection with whole calendar years.
+			if ( ! empty( $start_date ) && ! empty( $end_date ) ) {
+				$args['meta_query'][] = [
+					'key'     => 'edbs_meeting_date',
+					'value'   => [ $start_date, $end_date ],
+					'compare' => 'BETWEEN',
+					'type'    => 'DATE',
+				];
+			} elseif ( ! empty( $start_date ) ) {
+				$args['meta_query'][] = [
+					'key'     => 'edbs_meeting_date',
+					'value'   => $start_date,
+					'compare' => '>=',
+					'type'    => 'DATE',
+				];
+			} else {
+				$args['meta_query'][] = [
+					'key'     => 'edbs_meeting_date',
+					'value'   => $end_date,
+					'compare' => '<=',
+					'type'    => 'DATE',
+				];
+			}
+		} elseif ( ! empty( $included_years ) ) {
 			$years        = explode( ',', $included_years );
 			$year_queries = [ 'relation' => 'OR' ];
 

--- a/includes/Shortcode/FieldRegistry.php
+++ b/includes/Shortcode/FieldRegistry.php
@@ -35,6 +35,7 @@ class FieldRegistry {
 	const TYPE_SELECT          = 'select';
 	const TYPE_NUMBER          = 'number';
 	const TYPE_NUMBER_WITH_ALL = 'number_with_all';
+	const TYPE_DATE            = 'date';
 
 	/**
 	 * Hooks the free plugin's own fields into the registry filter.
@@ -118,6 +119,33 @@ class FieldRegistry {
 					'placeholder' => '2023,2024',
 					'description' => __( 'Comma-separated list of years. Leave blank to show all years.', 'boardscribe' ),
 					'rest_arg'    => true,
+				],
+				[
+					'key'               => 'start_date',
+					'type'              => self::TYPE_DATE,
+					'group'             => 'general',
+					'label'             => __( 'Start Date', 'boardscribe' ),
+					'default'           => '',
+					// Fiscal-year (or any other custom range) filtering that
+					// included_years can't express — e.g. a July-to-June
+					// school year. Takes priority over included_years when
+					// either start_date or end_date is set (see
+					// BoardScribeEndpoint::get_meetings()).
+					'description'       => __( 'Only show meetings on or after this date. Takes priority over Included Years.', 'boardscribe' ),
+					'sanitize_callback' => [ __CLASS__, 'sanitize_iso_date' ],
+					'validate_callback' => [ __CLASS__, 'validate_iso_date_or_empty' ],
+					'rest_arg'          => true,
+				],
+				[
+					'key'               => 'end_date',
+					'type'              => self::TYPE_DATE,
+					'group'             => 'general',
+					'label'             => __( 'End Date', 'boardscribe' ),
+					'default'           => '',
+					'description'       => __( 'Only show meetings on or before this date. Takes priority over Included Years.', 'boardscribe' ),
+					'sanitize_callback' => [ __CLASS__, 'sanitize_iso_date' ],
+					'validate_callback' => [ __CLASS__, 'validate_iso_date_or_empty' ],
+					'rest_arg'          => true,
 				],
 				[
 					'key'      => 'posts_per_page',
@@ -401,6 +429,50 @@ class FieldRegistry {
 	public static function sanitize_date_format( $value, string $default_value ): string {
 		$value = sanitize_text_field( (string) $value );
 		return BoardScribeEndpoint::validate_date_format( $value ) ? $value : $default_value;
+	}
+
+	/**
+	 * Sanitizes a start_date/end_date value, falling back to an empty
+	 * string (no filter) for anything that isn't a valid Y-m-d date —
+	 * same fallback-to-safe-default pattern as sanitize_date_format().
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $value Raw start_date/end_date value.
+	 * @return string A Y-m-d date string, or ''.
+	 */
+	public static function sanitize_iso_date( $value ): string {
+		$value = sanitize_text_field( (string) $value );
+		return self::validate_iso_date_or_empty( $value ) ? $value : '';
+	}
+
+	/**
+	 * Validates a start_date/end_date REST param: either empty (no
+	 * filter) or a real calendar date in Y-m-d form.
+	 *
+	 * Rejects non-existent calendar dates (e.g. "2024-02-30") rather than
+	 * relying on DateTime's silent rollover to the next valid date -
+	 * checkdate() is the strict check purpose-built for this.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $value The raw start_date/end_date value.
+	 * @return bool
+	 */
+	public static function validate_iso_date_or_empty( $value ): bool {
+		if ( ! is_string( $value ) ) {
+			return false;
+		}
+
+		if ( '' === $value ) {
+			return true;
+		}
+
+		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $value, $matches ) ) {
+			return false;
+		}
+
+		return checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,7 @@ Use the **Settings > Shortcode Builder** to generate the shortcode with your pre
 **Attributes:**
 
 * `included_years` - Comma-separated years to display (e.g. `2023,2024`). Default: all years.
+* `start_date`, `end_date` - Only show meetings in this date range (`YYYY-MM-DD`, inclusive on both ends). Either can be used alone for an open-ended range. Takes priority over `included_years` when set — useful for fiscal years that don't align to the calendar year (e.g. `start_date="2025-07-01" end_date="2026-06-30"`).
 * `posts_per_page` - Entries per page. Use `-1` to show all. Default: `20`.
 * `held_date_format` - PHP date format for meetings that were held. Default: `l, F j, Y`.
 * `not_held_date_format` - PHP date format for meetings not held. Default: `F Y`.
@@ -138,6 +139,10 @@ Yes. BoardScribe outputs a standard, accessible HTML table through a shortcode, 
 = Can I display meetings for specific years only? =
 
 Yes. Use the `included_years` shortcode attribute with a comma-separated list of years: `[edbs_boardscribe included_years="2023,2024"]`.
+
+= Can I display meetings for a fiscal year that doesn't match the calendar year? =
+
+Yes. Use the `start_date` and `end_date` shortcode attributes for an arbitrary date range: `[edbs_boardscribe start_date="2025-07-01" end_date="2026-06-30"]`.
 
 = Can I use the shortcode more than once on the same page? =
 

--- a/src/js/block/index.js
+++ b/src/js/block/index.js
@@ -14,6 +14,7 @@ import { useRef } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import metadata from '../../../block.json';
+import { withDateFilterHelpText } from '../shared/date-filter-help-text';
 import { GenericFieldControl } from '../shared/generic-field-control';
 
 // Localized by BoardScribeBlock::register_block() from the shared
@@ -91,7 +92,12 @@ registerBlockType( metadata.name, {
 			( fieldsByGroup[ group ] || [] ).map( ( field ) => (
 				<GenericFieldControl
 					key={ field.attributeKey }
-					field={ field }
+					field={ withDateFilterHelpText(
+						field,
+						attributes.includedYears,
+						attributes.startDate,
+						attributes.endDate,
+					) }
 					value={ attributes[ field.attributeKey ] }
 					onChange={ ( val ) => setAttributes( { [ field.attributeKey ]: val } ) }
 				/>

--- a/src/js/builder/app.js
+++ b/src/js/builder/app.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/components';
 import { useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { withDateFilterHelpText } from '../shared/date-filter-help-text';
 import { GenericFieldControl } from '../shared/generic-field-control';
 import { buildShortcode } from './build-shortcode';
 import { Preview } from './preview';
@@ -111,9 +112,15 @@ export function BuilderApp( { fields } ) {
 	const setValue = ( key, value ) => setValues( ( prev ) => ( { ...prev, [ key ]: value } ) );
 
 	const renderField = ( field ) => {
+		const resolvedField = withDateFilterHelpText(
+			field,
+			values.included_years,
+			values.start_date,
+			values.end_date,
+		);
 		const props = {
 			key: field.key,
-			field,
+			field: resolvedField,
 			value: values[ field.key ],
 			onChange: ( val ) => setValue( field.key, val ),
 		};

--- a/src/js/defaults/request.js
+++ b/src/js/defaults/request.js
@@ -20,6 +20,8 @@ import { apiBaseUrl } from '../config';
 export function defaultBuildRequestUrl( instanceCfg, page ) {
 	const url = new URL( apiBaseUrl, window.location.origin );
 	url.searchParams.set( 'included_years', instanceCfg.includedYears || '' );
+	url.searchParams.set( 'start_date', instanceCfg.startDate || '' );
+	url.searchParams.set( 'end_date', instanceCfg.endDate || '' );
 	url.searchParams.set( 'held_date_format', instanceCfg.heldDateFormat || 'l, F j, Y' );
 	url.searchParams.set( 'not_held_date_format', instanceCfg.notHeldDateFormat || 'F Y' );
 	url.searchParams.set( 'posts_per_page', instanceCfg.postsPerPage || 20 );

--- a/src/js/shared/date-filter-help-text.js
+++ b/src/js/shared/date-filter-help-text.js
@@ -1,0 +1,49 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Overrides a field's description with a conditional note about how
+ * included_years/start_date/end_date interact - start_date/end_date
+ * silently take priority over included_years whenever either is set
+ * (see BoardScribeEndpoint::get_meetings()), which isn't obvious from
+ * the three fields' own static descriptions alone once more than one
+ * has a value. Every other field is returned unchanged.
+ *
+ * Shared by the shortcode builder app and the block editor sidebar,
+ * which key their values differently (snake_case shortcode attribute
+ * vs. camelCase block attribute) - callers pass the three current
+ * values directly rather than this function assuming a naming
+ * convention.
+ *
+ * @param {Object} field         The field descriptor being rendered.
+ * @param {string} includedYears Current included_years value.
+ * @param {string} startDate     Current start_date value.
+ * @param {string} endDate       Current end_date value.
+ * @return {Object} The field descriptor, with `description` overridden if applicable.
+ */
+export function withDateFilterHelpText( field, includedYears, startDate, endDate ) {
+	const hasRange = Boolean( startDate || endDate );
+	const hasYears = Boolean( includedYears );
+
+	if ( 'included_years' === field.key && hasRange ) {
+		return {
+			...field,
+			description: __( 'Ignored: a start/end date is set below, which takes priority.', 'boardscribe' ),
+		};
+	}
+
+	if ( 'start_date' === field.key && hasYears && ! hasRange ) {
+		return {
+			...field,
+			description: __( 'Only show meetings on or after this date. Overrides Included Years above as soon as either date is set.', 'boardscribe' ),
+		};
+	}
+
+	if ( 'end_date' === field.key && hasYears && ! hasRange ) {
+		return {
+			...field,
+			description: __( 'Only show meetings on or before this date. Overrides Included Years above as soon as either date is set.', 'boardscribe' ),
+		};
+	}
+
+	return field;
+}

--- a/src/js/shared/generic-field-control.js
+++ b/src/js/shared/generic-field-control.js
@@ -84,6 +84,18 @@ export function GenericFieldControl( { field, value = '', onChange, controlProps
 				/>
 			);
 
+		case 'date':
+			return (
+				<TextControl
+					type="date"
+					label={ field.label }
+					help={ help }
+					value={ value }
+					onChange={ onChange }
+					{ ...controlProps }
+				/>
+			);
+
 		case 'text':
 		default:
 			return (

--- a/tests/phpunit/BoardScribeEndpointRestTest.php
+++ b/tests/phpunit/BoardScribeEndpointRestTest.php
@@ -146,4 +146,105 @@ class BoardScribeEndpointRestTest extends TestCase {
 
 		$this->assertSame( 0, $data['total_entries'] );
 	}
+
+	/**
+	 * start_date and end_date together filter to an arbitrary range that
+	 * spans a calendar year boundary — the fiscal-year use case
+	 * included_years can't express (see boardscribe#48).
+	 */
+	public function test_start_and_end_date_filter_a_fiscal_year_range(): void {
+		$this->create_meeting( [ 'edbs_meeting_date' => '2025-06-30' ] ); // Just before the range.
+		$this->create_meeting( [ 'edbs_meeting_date' => '2025-07-01' ] ); // Range start, inclusive.
+		$this->create_meeting( [ 'edbs_meeting_date' => '2026-01-15' ] ); // Inside the range.
+		$this->create_meeting( [ 'edbs_meeting_date' => '2026-06-30' ] ); // Range end, inclusive.
+		$this->create_meeting( [ 'edbs_meeting_date' => '2026-07-01' ] ); // Just after the range.
+
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'start_date', '2025-07-01' );
+		$request->set_param( 'end_date', '2026-06-30' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 3, $data['total_entries'] );
+	}
+
+	/**
+	 * start_date alone is an open-ended "on or after" filter.
+	 */
+	public function test_start_date_alone_filters_open_ended(): void {
+		$this->create_meeting( [ 'edbs_meeting_date' => '2024-01-01' ] );
+		$this->create_meeting( [ 'edbs_meeting_date' => '2025-01-01' ] );
+
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'start_date', '2024-06-01' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 1, $data['total_entries'] );
+	}
+
+	/**
+	 * end_date alone is an open-ended "on or before" filter.
+	 */
+	public function test_end_date_alone_filters_open_ended(): void {
+		$this->create_meeting( [ 'edbs_meeting_date' => '2024-01-01' ] );
+		$this->create_meeting( [ 'edbs_meeting_date' => '2025-01-01' ] );
+
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'end_date', '2024-06-01' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 1, $data['total_entries'] );
+	}
+
+	/**
+	 * A start_date/end_date range takes priority over included_years
+	 * entirely when both are sent — not combined/intersected with it —
+	 * since a caller sending both almost certainly means the explicit
+	 * range.
+	 */
+	public function test_start_date_takes_priority_over_included_years(): void {
+		$this->create_meeting( [ 'edbs_meeting_date' => '2023-05-01' ] );
+		$this->create_meeting( [ 'edbs_meeting_date' => '2024-05-01' ] );
+
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'included_years', '2024' );
+		$request->set_param( 'start_date', '2023-01-01' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Both meetings fall on/after 2023-01-01, so start_date alone
+		// (ignoring included_years=2024) returns both.
+		$this->assertSame( 2, $data['total_entries'] );
+	}
+
+	/**
+	 * An invalid (non-existent) start_date is rejected with 400 by the
+	 * route's own validate_callback, end to end.
+	 */
+	public function test_invalid_start_date_is_rejected_with_400(): void {
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'start_date', '2024-02-30' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * An invalid end_date is rejected with 400 too.
+	 */
+	public function test_invalid_end_date_is_rejected_with_400(): void {
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'end_date', 'not-a-date' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
 }

--- a/tests/phpunit/BoardScribeShortcodeTest.php
+++ b/tests/phpunit/BoardScribeShortcodeTest.php
@@ -114,6 +114,41 @@ class BoardScribeShortcodeTest extends TestCase {
 	}
 
 	/**
+	 * A valid start_date/end_date is preserved into the instance config
+	 * under its camelCase key.
+	 */
+	public function test_valid_start_and_end_date_are_preserved(): void {
+		$html   = $this->shortcode->render(
+			[
+				'start_date' => '2025-07-01',
+				'end_date'   => '2026-06-30',
+			]
+		);
+		$config = $this->get_instance_config( $html );
+
+		$this->assertSame( '2025-07-01', $config['startDate'] );
+		$this->assertSame( '2026-06-30', $config['endDate'] );
+	}
+
+	/**
+	 * An invalid (non-existent) start_date/end_date falls back to an
+	 * empty string (no filter) rather than reaching the instance config
+	 * as an unchecked value.
+	 */
+	public function test_invalid_start_and_end_date_fall_back_to_empty_string(): void {
+		$html   = $this->shortcode->render(
+			[
+				'start_date' => '2024-02-30',
+				'end_date'   => 'not-a-date',
+			]
+		);
+		$config = $this->get_instance_config( $html );
+
+		$this->assertSame( '', $config['startDate'] );
+		$this->assertSame( '', $config['endDate'] );
+	}
+
+	/**
 	 * With no template attribute, the config carries an empty template
 	 * name, which the JS resolves to the built-in table template.
 	 */

--- a/tests/phpunit/FieldRegistryValidateIsoDateTest.php
+++ b/tests/phpunit/FieldRegistryValidateIsoDateTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tests for FieldRegistry::validate_iso_date_or_empty() and sanitize_iso_date().
+ *
+ * @package EqualizeDigital\BoardScribe
+ */
+
+use EqualizeDigital\BoardScribe\Shortcode\FieldRegistry;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers the REST validate_callback/sanitize_callback pair that gates
+ * start_date/end_date (see boardscribe#48 — fiscal-year-friendly date
+ * range filtering, since included_years can't express a non-calendar-year
+ * range).
+ */
+class FieldRegistryValidateIsoDateTest extends TestCase {
+
+	/**
+	 * An empty string is valid — it means "no filter", not "invalid date".
+	 */
+	public function test_empty_string_is_valid(): void {
+		$this->assertTrue( FieldRegistry::validate_iso_date_or_empty( '' ) );
+	}
+
+	/**
+	 * Ordinary Y-m-d dates are accepted.
+	 *
+	 * @dataProvider provide_valid_dates
+	 * @param string $date Date string under test.
+	 */
+	public function test_accepts_valid_dates( string $date ): void {
+		$this->assertTrue( FieldRegistry::validate_iso_date_or_empty( $date ) );
+	}
+
+	/**
+	 * Data provider for valid Y-m-d dates.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_valid_dates(): array {
+		return [
+			'ordinary date' => [ '2024-03-15' ],
+			'leap day'      => [ '2024-02-29' ],
+			'year boundary' => [ '2023-12-31' ],
+		];
+	}
+
+	/**
+	 * A non-existent calendar date (e.g. Feb 30, or a non-leap-year Feb 29)
+	 * is rejected outright via checkdate() rather than silently rolling
+	 * forward to the next valid date - the same class of bug fixed in
+	 * CsvImporter::parse_publish_date() (see boardscribe-pro).
+	 *
+	 * @dataProvider provide_invalid_calendar_dates
+	 * @param string $date Date string under test.
+	 */
+	public function test_rejects_invalid_calendar_dates( string $date ): void {
+		$this->assertFalse( FieldRegistry::validate_iso_date_or_empty( $date ) );
+	}
+
+	/**
+	 * Data provider for well-formed but non-existent calendar dates.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_invalid_calendar_dates(): array {
+		return [
+			'february 30th'        => [ '2024-02-30' ],
+			'non-leap-year feb 29' => [ '2023-02-29' ],
+			'month 13'             => [ '2024-13-01' ],
+			'day 32'               => [ '2024-01-32' ],
+		];
+	}
+
+	/**
+	 * Malformed strings (wrong separators, wrong segment lengths, extra
+	 * text) are rejected.
+	 *
+	 * @dataProvider provide_malformed_strings
+	 * @param string $date Date string under test.
+	 */
+	public function test_rejects_malformed_strings( string $date ): void {
+		$this->assertFalse( FieldRegistry::validate_iso_date_or_empty( $date ) );
+	}
+
+	/**
+	 * Data provider for malformed date strings.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_malformed_strings(): array {
+		return [
+			'slashes instead of dashes' => [ '2024/03/15' ],
+			'two-digit year'            => [ '24-03-15' ],
+			'trailing text'              => [ '2024-03-15 extra' ],
+			'not a date at all'         => [ 'not-a-date' ],
+		];
+	}
+
+	/**
+	 * Non-string input (e.g. an array from a repeated query param) must
+	 * fail validation cleanly rather than throw a TypeError.
+	 */
+	public function test_rejects_non_string_input_without_throwing(): void {
+		$this->assertFalse( FieldRegistry::validate_iso_date_or_empty( [ 'not', 'a', 'string' ] ) );
+	}
+
+	/**
+	 * sanitize_iso_date() passes a valid date through unchanged.
+	 */
+	public function test_sanitize_passes_through_a_valid_date(): void {
+		$this->assertSame( '2024-03-15', FieldRegistry::sanitize_iso_date( '2024-03-15' ) );
+	}
+
+	/**
+	 * sanitize_iso_date() falls back to an empty string (no filter) for an
+	 * invalid calendar date, rather than passing through a value that
+	 * would otherwise reach meta_query's BETWEEN/>=/<= comparisons unchecked.
+	 */
+	public function test_sanitize_falls_back_to_empty_string_for_invalid_date(): void {
+		$this->assertSame( '', FieldRegistry::sanitize_iso_date( '2024-02-30' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #48. `included_years` can only filter to whole calendar years, which doesn't work for organizations with a fiscal year that differs from the calendar year — the reported case is Highland's fiscal-year school-board setup (`start_date="2026-07-01" end_date="2027-06-30"`), matching what their fork of this plugin already supports.

- Adds `start_date` / `end_date` shortcode attributes accepting a `Y-m-d` date, either usable alone for an open-ended range (`start_date` only = "on or after"; `end_date` only = "on or before").
- When either is set, they take priority over `included_years` entirely (not combined/intersected with it) — a caller sending both almost certainly means the explicit range.
- Registered on the shared `FieldRegistry`, so the new attributes automatically become: a shortcode attribute, a REST route arg, a block attribute, and a control in both the Shortcode Builder admin page and the block editor's InspectorControls sidebar — no per-consumer wiring needed.
- Added a new `date` field type (`FieldRegistry::TYPE_DATE`) rendered as a native HTML date input via the shared `GenericFieldControl`.
- `BoardScribeEndpoint::get_meetings()` builds the corresponding `meta_query` (`BETWEEN` / `>=` / `<=` against `edbs_meeting_date`, same as the existing year filter).
- `BoardScribeBlock::render_editor_preview()` mirrors the same range logic for the block editor's server-rendered preview — using `meta_query` against `edbs_meeting_date`, consistent with the real query (the existing `includedYears` editor-preview code uses `date_query` against `post_date` instead, which is a separate pre-existing inconsistency, not touched here).
- Validation rejects malformed and non-existent calendar dates (e.g. `2024-02-30`) via `checkdate()`, same defense-in-depth pattern as the existing `held_date_format`/`not_held_date_format` fields.
- `start_date`/`end_date` block attributes are sanitized through `FieldRegistry::sanitize_iso_date()` before reaching the editor preview's query, matching the frontend shortcode path (CodeRabbit finding, fixed).
- **Conditional help text**: since `included_years` and `start_date`/`end_date` are independent fields that can both hold values at once, with the date range silently winning, each field's description now says so explicitly — `included_years` shows "Ignored: a start/end date is set below, which takes priority" once either date is set, and the date fields note they override it. Applies identically in the Shortcode Builder page and the block editor sidebar.

## Test plan
- [x] `composer lint` / `phpcs` clean
- [x] `npm run lint:js` clean
- [x] `npm run build` — all three webpack bundles compile
- [x] Full PHPUnit suite (via Docker, `scripts/setup-phpunit.sh`) — 119 tests / 212 assertions, including:
  - `FieldRegistryValidateIsoDateTest` — validation/sanitization of `start_date`/`end_date` values
  - `BoardScribeEndpointRestTest` — real dispatched-request coverage of range filtering, open-ended filtering, priority over `included_years`, and 400s on invalid dates
  - `BoardScribeShortcodeTest` — instance-config resolution, including fallback to empty string for an invalid date
- [x] Manually verified in the browser: Shortcode Builder date pickers and block editor sidebar date pickers render, filter live preview data correctly (fiscal-year range, open-ended start/end, priority-over-included_years), and show the correct conditional help text in both places

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inclusive `start_date`/`end_date` filters for meeting listings, including open-ended ranges for fiscal periods crossing calendar years.
  * Added `start_date` and `end_date` fields across the builder, editor preview, shortcodes, and REST request parameters, with date-specific help text and a date input UI.
  * Date-range filters now take priority over `included_years`.
* **Bug Fixes**
  * Invalid `start_date`/`end_date` values are rejected by REST (400) and cleared in shortcode/builder config to prevent malformed filtering.
* **Documentation**
  * Updated shortcode guidance and added examples for fiscal-year ranges using `start_date`/`end_date`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->