### PR TITLE
chore(security): bump squizlabs/php_codesniffer to 3.13.6 (CVE-2026-67434)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2642,16 +2642,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -2717,7 +2717,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
## Summary
Same CVE as the companion fixes across the plugin family: `squizlabs/php_codesniffer` 3.13.5 has [GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq) (published 2026-08-06), a command injection vulnerability in the Gitblame/Hgblame/Svnblame report generators via crafted filenames. Fixed upstream in 3.13.6.

`wp-coding-standards/wpcs` was already patched to 3.4.1 on `main`, so this only needed the one package bump.

Dev-only dependency, never shipped to end users. Least-invasive fix: `composer update squizlabs/php_codesniffer` alone - touches only `composer.lock`.

## Test plan
- [x] `composer.lock` diff confirmed to touch only this one package
- [x] `composer check-cs` passes clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)