### PR TITLE
docs: replace placeholder @since annotations

### DIFF
--- a/includes/Admin/MetaBox.php
+++ b/includes/Admin/MetaBox.php
@@ -22,7 +22,7 @@ class MetaBox {
 	/**
 	 * Hooks meta registration and meta box into WordPress.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -36,7 +36,7 @@ class MetaBox {
 	/**
 	 * Enqueues the media library and the meta box picker script.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $hook The current admin page hook.
 	 * @return void
@@ -61,7 +61,7 @@ class MetaBox {
 	/**
 	 * Returns the inline JavaScript for the media library URL picker.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return string
 	 */
@@ -100,7 +100,7 @@ JS;
 	/**
 	 * Registers the four meeting meta fields for the REST API and block editor.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -172,7 +172,7 @@ JS;
 	/**
 	 * Registers the Meeting Details meta box on the edit screen.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -181,7 +181,7 @@ JS;
 		 * Filters whether to show the native meta box UI. Return false to replace
 		 * it with a custom UI.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param bool $show Whether to show the native meta box.
 		 */
@@ -202,7 +202,7 @@ JS;
 	/**
 	 * Renders the Meeting Details meta box HTML.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param \WP_Post $post The current post object.
 	 * @return void
@@ -219,7 +219,7 @@ JS;
 		 * Fires before the default meta box fields are rendered. Pro plugin can
 		 * use this to prepend additional fields.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param \WP_Post $post The current post.
 		 */
@@ -231,7 +231,7 @@ JS;
 	/**
 	 * Saves the meeting meta fields on post save.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param int $post_id The post ID being saved.
 	 * @return void
@@ -280,7 +280,7 @@ JS;
 		 * Fires after the default meta fields are saved. Pro plugin can hook here
 		 * to save additional meta.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param int $post_id The post ID.
 		 */
@@ -298,7 +298,7 @@ JS;
 	 * and unhooks its own save handler around wp_update_post() to avoid a
 	 * save_post recursion loop.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param int $post_id The post ID being saved.
 	 * @return void
@@ -336,7 +336,7 @@ JS;
 	 * Builds the default meeting title ("Board Meeting" plus the formatted
 	 * meeting date). Public and filterable so Pro can reuse or override it.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $meeting_date The raw edbs_meeting_date meta value (Y-m-d).
 	 * @param int    $post_id      The post ID the title is being generated for.
@@ -363,7 +363,7 @@ JS;
 		 * Filters the auto-generated title used when a meeting is saved without
 		 * one. Pro plugin can override the format (e.g. include the meeting series).
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param string $title        The generated title.
 		 * @param string $meeting_date The raw meeting date meta value.

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -49,7 +49,7 @@ class SettingsPage {
 	/**
 	 * Hooks settings registration and admin menu into WordPress.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -62,7 +62,7 @@ class SettingsPage {
 	/**
 	 * Returns the settings page tab definitions, keyed by tab slug.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return array<string, array{icon:string,label:string}>
 	 */
@@ -89,7 +89,7 @@ class SettingsPage {
 		 * controls display order, so a callback can splice a tab in before
 		 * "support" rather than only appending.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param array<string, array{icon:string,label:string}> $tabs Tab definitions.
 		 */
@@ -100,7 +100,7 @@ class SettingsPage {
 	 * Returns the current tab slug, defaulting to "general" when absent or
 	 * unrecognized.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return string
 	 */
@@ -114,7 +114,7 @@ class SettingsPage {
 	/**
 	 * Builds the admin URL for a settings tab.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $tab The tab slug.
 	 * @return string
@@ -133,7 +133,7 @@ class SettingsPage {
 	/**
 	 * Adds the Settings submenu under the BoardScribe CPT menu.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -151,7 +151,7 @@ class SettingsPage {
 	/**
 	 * Registers the persistent plugin settings.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -186,7 +186,7 @@ class SettingsPage {
 	 * Enqueues settings-page assets, plus the shortcode builder app on the
 	 * builder tab (its live preview runs the real frontend pipeline).
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $hook The current admin page hook.
 	 * @return void
@@ -242,7 +242,7 @@ class SettingsPage {
 	/**
 	 * Renders the General section intro copy.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -253,7 +253,7 @@ class SettingsPage {
 	/**
 	 * Renders the delete on uninstall settings field.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -286,7 +286,7 @@ class SettingsPage {
 	/**
 	 * Sanitizes settings before saving.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $input Raw input from the settings form.
 	 * @return array Sanitized settings.
@@ -300,7 +300,7 @@ class SettingsPage {
 	/**
 	 * Renders the settings page HTML.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -317,7 +317,7 @@ class SettingsPage {
 	/**
 	 * Renders the sidebar tab navigation.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $current_tab The active tab slug.
 	 * @return void
@@ -342,7 +342,7 @@ class SettingsPage {
 	/**
 	 * Renders the panel header (icon + label) for the current tab.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $current_tab The active tab slug.
 	 * @return void
@@ -364,7 +364,7 @@ class SettingsPage {
 	/**
 	 * Renders the active tab's panel content.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $current_tab The active tab slug.
 	 * @return void
@@ -390,7 +390,7 @@ class SettingsPage {
 				 * Only fires for tabs present in the (filtered) tab list, since
 				 * get_current_tab() falls back to "general" for unknown slugs.
 				 *
-				 * @since x.x.x
+				 * @since 1.0.0
 				 */
 				do_action( "edbs_settings_tab_content_{$current_tab}" );
 				break;
@@ -400,7 +400,7 @@ class SettingsPage {
 	/**
 	 * Renders the General tab (persistent settings form).
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -419,7 +419,7 @@ class SettingsPage {
 		 * for sections with their own form (e.g. license management) that don't use
 		 * the Settings API.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 */
 		do_action( 'edbs_settings_fields' );
 	}
@@ -427,7 +427,7 @@ class SettingsPage {
 	/**
 	 * Renders the Shortcode Builder tab (React app mount point).
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -443,7 +443,7 @@ class SettingsPage {
 	/**
 	 * Renders the Support tab (documentation and contact links).
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */

--- a/includes/Block/BoardScribeBlock.php
+++ b/includes/Block/BoardScribeBlock.php
@@ -44,7 +44,7 @@ class BoardScribeBlock {
 	 * that registration land first (and skipping ours below) keeps an
 	 * old-Pro/new-free combination working with no _doing_it_wrong notice.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -62,7 +62,7 @@ class BoardScribeBlock {
 	 * Pro build has already added it (see register_block() for the same
 	 * old-Pro concern).
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $categories Existing block categories.
 	 * @return array The category list with the BoardScribe category appended.
@@ -86,7 +86,7 @@ class BoardScribeBlock {
 	/**
 	 * Registers the block type from block.json with a PHP render callback.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -129,7 +129,7 @@ class BoardScribeBlock {
 	 * array shallow-merges over block.json's metadata, so this replaces
 	 * block.json's own (absent) "attributes" key entirely.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return array<string, array{type: string, default: mixed}>
 	 */
@@ -168,7 +168,7 @@ class BoardScribeBlock {
 	 * server-rendered HTML table is returned so the editor shows real content.
 	 * On the front end the JS-driven shortcode output is returned as normal.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array  $attributes Block attributes from the editor.
 	 * @param string $content    Inner block content (unused — no inner blocks).
@@ -188,7 +188,7 @@ class BoardScribeBlock {
 	/**
 	 * Builds a shortcode attribute string from block attributes.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $attributes Block attributes.
 	 * @return string Shortcode attribute string (leading space included if non-empty).
@@ -227,7 +227,7 @@ class BoardScribeBlock {
 	 * edbs_meeting_row_data filter, so Pro row fields are present — and
 	 * renders a static table over a filterable column list.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $attributes Block attributes.
 	 * @return string HTML preview.
@@ -241,7 +241,7 @@ class BoardScribeBlock {
 		 * year-timeline, which wants more than one year group visible)
 		 * can raise it.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param int   $max_rows   Maximum preview rows. Default 5.
 		 * @param array $attributes Block attributes.
@@ -358,7 +358,7 @@ class BoardScribeBlock {
 		 *                                 added via edbs_meeting_row_data are available.
 		 * }
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param array $columns    Column definitions, see above.
 		 * @param array $attributes Block attributes.
@@ -372,7 +372,7 @@ class BoardScribeBlock {
 		 * that owns a display template hooks here (e.g. Pro's year-timeline
 		 * renders one table per year via render_preview_table()).
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param string|null        $preview    The preview HTML, or null to use the default.
 		 * @param array              $attributes Block attributes.
@@ -396,7 +396,7 @@ class BoardScribeBlock {
 	 * of re-implementing the table markup — the PHP analogue of the front
 	 * end's window.edbsBuildTable().
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $columns    Column definitions, see the edbs_block_preview_columns filter.
 	 * @param array $rows       List of { post: \WP_Post, row: array } entries.
@@ -425,7 +425,7 @@ class BoardScribeBlock {
 	 * mirroring the front-end table template's label resolution and
 	 * hide-toggle handling (src/js/templates/table.js).
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $attributes Block attributes.
 	 * @return array Column definitions, see the edbs_block_preview_columns filter.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -42,7 +42,7 @@ class Plugin {
 	/**
 	 * Returns the single instance.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return Plugin
 	 */
@@ -56,14 +56,14 @@ class Plugin {
 	/**
 	 * Private constructor — use get_instance().
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 */
 	private function __construct() {}
 
 	/**
 	 * Boots the plugin. Hooked to plugins_loaded.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -90,7 +90,7 @@ class Plugin {
 		/**
 		 * Fires after all free plugin components are registered. Pro plugin's sole entry point.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param Plugin $plugin The plugin instance.
 		 */
@@ -100,7 +100,7 @@ class Plugin {
 	/**
 	 * Adds agenda/minutes link filters for Accessibility Checker Pro.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $additional_filters Existing filter names.
 	 * @return array
@@ -114,7 +114,7 @@ class Plugin {
 	/**
 	 * Gets a single plugin setting with fallback to defaults.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $key           The setting key.
 	 * @param mixed  $default_value Optional override default (falls back to DEFAULTS constant).

--- a/includes/PostType/BoardScribeCPT.php
+++ b/includes/PostType/BoardScribeCPT.php
@@ -19,7 +19,7 @@ class BoardScribeCPT {
 	/**
 	 * Hooks the CPT registration into WordPress init.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -30,7 +30,7 @@ class BoardScribeCPT {
 	/**
 	 * Registers the edbs_meeting custom post type.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -66,7 +66,7 @@ class BoardScribeCPT {
 		 * Filters the edbs_meeting CPT registration args. Pro plugin uses
 		 * this to enable public/rewrite/archive support or a custom capability_type.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param array $args The register_post_type() args.
 		 */
@@ -76,7 +76,7 @@ class BoardScribeCPT {
 		 * Fires before the BoardScribe CPT is registered. Register taxonomies
 		 * that need to bind to the CPT here.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 */
 		do_action( 'edbs_before_register_cpt' );
 
@@ -86,7 +86,7 @@ class BoardScribeCPT {
 		 * Fires after the BoardScribe CPT is registered. Register taxonomies
 		 * or rewrite rules here.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 */
 		do_action( 'edbs_after_register_cpt' );
 	}

--- a/includes/REST/BoardScribeEndpoint.php
+++ b/includes/REST/BoardScribeEndpoint.php
@@ -25,7 +25,7 @@ class BoardScribeEndpoint {
 	/**
 	 * Hooks REST route registration into WordPress.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -36,7 +36,7 @@ class BoardScribeEndpoint {
 	/**
 	 * Registers the custom REST route.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -77,7 +77,7 @@ class BoardScribeEndpoint {
 		 * need a builder/block field should be registered on
 		 * edbs_shortcode_field_registry with rest_arg => true instead.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param array $args The REST route args schema.
 		 */
@@ -98,7 +98,7 @@ class BoardScribeEndpoint {
 	/**
 	 * Handles GET requests to the boardscribe endpoint.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param \WP_REST_Request $request The REST request object.
 	 * @return \WP_REST_Response
@@ -124,7 +124,7 @@ class BoardScribeEndpoint {
 			 * no-limit option must resolve to a bounded query — otherwise any
 			 * anonymous caller could request every record in one response.
 			 *
-			 * @since x.x.x
+			 * @since 1.0.0
 			 *
 			 * @param int $absolute_max Upper bound substituted for -1. Default 500.
 			 */
@@ -135,7 +135,7 @@ class BoardScribeEndpoint {
 			 *
 			 * Bounds arbitrary positive values sent directly to the public endpoint.
 			 *
-			 * @since x.x.x
+			 * @since 1.0.0
 			 *
 			 * @param int $max_per_page Maximum posts_per_page. Default 100.
 			 */
@@ -208,7 +208,7 @@ class BoardScribeEndpoint {
 		 * Filters the WP_Query args before querying meetings.
 		 * Pro plugin can add taxonomy queries, additional meta filters, etc.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param array            $args    The WP_Query args.
 		 * @param \WP_REST_Request $request The REST request.
@@ -247,7 +247,7 @@ class BoardScribeEndpoint {
 		 * Filters the full REST response before it is returned.
 		 * Pro plugin can add top-level fields (e.g., available categories).
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param array            $response The response data.
 		 * @param \WP_REST_Request $request  The REST request.
@@ -265,7 +265,7 @@ class BoardScribeEndpoint {
 	 * feed, a "most recent meeting" widget) can call this directly instead
 	 * of re-implementing the same escaping logic themselves.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param int                   $post_id     The meeting post ID.
 	 * @param array                 $format_args {
@@ -308,7 +308,7 @@ class BoardScribeEndpoint {
 		 * held/not-held status. Sort order is unaffected — it's driven by the
 		 * raw edbs_meeting_date value, not this display string.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param string $formatted_date   The computed/escaped date display string.
 		 * @param int    $post_id          The post ID.
@@ -356,7 +356,7 @@ class BoardScribeEndpoint {
 		 * Filters a single meeting row before it is added to the response.
 		 * Pro plugin can add extra fields (e.g., category, attachments).
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param array                  $row     The meeting row data.
 		 * @param int                    $post_id The post ID.
@@ -385,7 +385,7 @@ class BoardScribeEndpoint {
 	 * param), and a strict type hint would throw a TypeError instead of
 	 * just failing validation.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param mixed $value The raw held_date_format/not_held_date_format value.
 	 * @return bool
@@ -408,7 +408,7 @@ class BoardScribeEndpoint {
 	 * with the exact same format list as this endpoint, instead of
 	 * maintaining a copy that could silently diverge.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param string $date_string The raw date string from post meta.
 	 * @return \DateTime|null

--- a/includes/Shortcode/BoardScribeShortcode.php
+++ b/includes/Shortcode/BoardScribeShortcode.php
@@ -34,7 +34,7 @@ class BoardScribeShortcode {
 	/**
 	 * Hooks shortcode and asset enqueuing into WordPress.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -48,7 +48,7 @@ class BoardScribeShortcode {
 	 * content. Page builders that render shortcodes late are handled by the
 	 * fallback enqueue inside render().
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -68,7 +68,7 @@ class BoardScribeShortcode {
 	 * the edbsConfig localization and the edbs_enqueue_assets action, so
 	 * Pro's extra columns/templates render in the preview too.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -101,7 +101,7 @@ class BoardScribeShortcode {
 		 * Fires after the plugin assets are enqueued.
 		 * Pro plugin can enqueue its own assets here.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 */
 		do_action( 'edbs_enqueue_assets' );
 	}
@@ -110,7 +110,7 @@ class BoardScribeShortcode {
 	 * Calls wp_localize_script once per page load to pass global
 	 * config and i18n strings to the JavaScript.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -148,7 +148,7 @@ class BoardScribeShortcode {
 	/**
 	 * Renders the [edbs_boardscribe] shortcode output.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $atts Shortcode attributes.
 	 * @return string HTML output.
@@ -193,7 +193,7 @@ class BoardScribeShortcode {
 			 * Pro plugin can use this to render e.g. a search box, a date
 			 * range picker, or an "add to calendar" button.
 			 *
-			 * @since x.x.x
+			 * @since 1.0.0
 			 *
 			 * @param string $instance_id The unique instance ID for this shortcode invocation.
 			 * @param array  $atts        The resolved shortcode attributes.
@@ -215,7 +215,7 @@ class BoardScribeShortcode {
 			 * Pro plugin can use this to render e.g. a comment/feedback form
 			 * or a print button.
 			 *
-			 * @since x.x.x
+			 * @since 1.0.0
 			 *
 			 * @param string $instance_id The unique instance ID for this shortcode invocation.
 			 * @param array  $atts        The resolved shortcode attributes.

--- a/includes/Shortcode/FieldRegistry.php
+++ b/includes/Shortcode/FieldRegistry.php
@@ -40,7 +40,7 @@ class FieldRegistry {
 	/**
 	 * Hooks the free plugin's own fields into the registry filter.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
@@ -57,7 +57,7 @@ class FieldRegistry {
 	 * state to invalidate, matching every other single-purpose filter
 	 * in this plugin.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return array[] List of field descriptors, see add_core_fields().
 	 */
@@ -102,7 +102,7 @@ class FieldRegistry {
 	 *     @type string|null   $block_attribute_key Overrides the camelCase block-attribute key derived from $key/config_key.
 	 * }
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array[] $fields Field descriptors contributed by earlier-priority callbacks.
 	 * @return array[]
@@ -302,7 +302,7 @@ class FieldRegistry {
 	 * key/configKey/default for the builder's shortcode generation and
 	 * preview instance config.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @return array<int, array{key: string, attributeKey: string, configKey: string, type: string, group: string, label: string, default: mixed, choices: ?array, placeholder: ?string, description: ?string}>
 	 */
@@ -332,7 +332,7 @@ class FieldRegistry {
 	 * instance-config value, using the field's own sanitize_callback
 	 * if it has one, otherwise a built-in resolver for its type.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $field     The field descriptor, see add_core_fields().
 	 * @param mixed $raw_value The raw shortcode-attribute value.
@@ -384,7 +384,7 @@ class FieldRegistry {
 	 * field from its snake_case $key, unless the descriptor overrides
 	 * it explicitly.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $field The field descriptor.
 	 * @return string
@@ -402,7 +402,7 @@ class FieldRegistry {
 	 * name for instance config and the block attribute — unless the
 	 * descriptor overrides it explicitly (e.g. class -> className).
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param array $field The field descriptor.
 	 * @return string
@@ -420,7 +420,7 @@ class FieldRegistry {
 	 * by the held_date_format and not_held_date_format field descriptors,
 	 * which differ only in their fallback value.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param mixed  $value         Raw date-format value.
 	 * @param string $default_value Fallback value when invalid.
@@ -436,7 +436,7 @@ class FieldRegistry {
 	 * string (no filter) for anything that isn't a valid Y-m-d date —
 	 * same fallback-to-safe-default pattern as sanitize_date_format().
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param mixed $value Raw start_date/end_date value.
 	 * @return string A Y-m-d date string, or ''.
@@ -454,7 +454,7 @@ class FieldRegistry {
 	 * relying on DateTime's silent rollover to the next valid date -
 	 * checkdate() is the strict check purpose-built for this.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param mixed $value The raw start_date/end_date value.
 	 * @return bool
@@ -484,7 +484,7 @@ class FieldRegistry {
 	 * reaches the instance config, to prevent stored XSS via the
 	 * shortcode attribute.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param mixed $class_list Raw, space-separated class names.
 	 * @return string Sanitized, space-separated class names.
@@ -503,7 +503,7 @@ class FieldRegistry {
 	 * posts_per_page=0, not "all") or flip a mistyped negative like
 	 * "-5" into a positive 5. A genuine positive count is returned as-is.
 	 *
-	 * @since x.x.x
+	 * @since 1.0.0
 	 *
 	 * @param mixed $value The raw posts_per_page value.
 	 * @return int

--- a/partials/meta-box.php
+++ b/partials/meta-box.php
@@ -63,7 +63,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		 * field it takes priority over, rather than at the end of the box
 		 * with the generic edbs_meta_fields hook.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param \WP_Post $post The current post.
 		 */
@@ -98,7 +98,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		 * URL field it takes priority over, rather than at the end of the
 		 * box with the generic edbs_meta_fields hook.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param \WP_Post $post The current post.
 		 */
@@ -126,7 +126,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		 * Fires after the default meta box fields are rendered. Pro plugin can
 		 * use this to append additional fields.
 		 *
-		 * @since x.x.x
+		 * @since 1.0.0
 		 *
 		 * @param \WP_Post $post The current post.
 		 */


### PR DESCRIPTION
## Summary

- replace all 92 shipped PHP since x.x.x annotations with @since 1.0.0
- leave generated and third-party files unchanged
- complete the release-documentation cleanup tracked in [PRO-1193](https://linear.app/equalize-digital/issue/PRO-1193/replace-placeholder-since-annotations-before-the-100-release)

## Testing

- placeholder ripgrep acceptance check (no matches)
- PHP parallel lint (33/33 files passed)
- PHPCS
- git diff --check