### PR TITLE
fix: let theme styles apply to pagination buttons

### DIFF
--- a/assets/css/boardscribe.css
+++ b/assets/css/boardscribe.css
@@ -1,20 +1,17 @@
 .edbs-pagination-buttons {
     display: flex;
     gap: 5px;
+    margin-top: 10px;
 }
 
 .edbs-pagination-button {
-    padding: 5px 10px;
-    border: none;
-    /* White text at ~7:1 against this shade, passing WCAG AA/AAA for
-       normal text - the previous #007bff was only ~4:1, failing AA. */
-    background-color: #0056b3;
-    color: white;
+    padding: 10px 15px;
     cursor: pointer;
 }
 
 .edbs-pagination-button.current {
-    background-color: #003d80;
+    text-decoration: underline;
+    font-weight: 700;
 }
 
 .edbs-pagination-button[disabled] {


### PR DESCRIPTION
## Summary
- Removes hardcoded `color`/`background-color`/`border: none` from `.edbs-pagination-button` and `.edbs-pagination-button.current` so the active theme's button styling applies instead
- Adds `margin-top: 10px` on `.edbs-pagination-buttons` and increases `.edbs-pagination-button` padding to `10px 15px` for better tap-target sizing
- Marks the current page with `text-decoration: underline; font-weight: 700;` instead of a darker background, so the indicator isn't color-only (pairs with the existing `aria-current="true"` on that button)

Closes #69

## Test plan
- [x] Verified in the Shortcode Builder live preview (posts_per_page=3) — buttons pick up theme styling, current page shows underline/bold
- [x] Verified on a real frontend page under Twenty Twenty-Five (theme-neutral buttons) and Astra (theme's blue buttons) — underline indicator visible in both
- [x] Confirmed `aria-current="true"` was already present on the current-page button and is untouched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqysyMu4h1jfWoYhuNCQAJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved pagination controls with larger buttons and better spacing.
  * Updated the active page indicator to use bold, underlined text.
  * Removed default button styling for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->