### PR TITLE
chore: bump Tested up to 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: equalizedigital, stevejonesdev, alh0319, williampatton
 Tags: board meetings, meeting minutes, meeting agenda, accessibility, minutes
 Requires at least: 6.7
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 1.0.0
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
## Summary
- WordPress 7.1 is current; bumps readme.txt's `Tested up to` from 7.0 to 7.1 so the WordPress version checker workflow (`.github/workflows/wp-version-checker.yml`) stops flagging it as stale.

## Test plan
- [x] No functional change — metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqysyMu4h1jfWoYhuNCQAJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compatibility information to indicate the plugin has been tested with WordPress 7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->