### PR TITLE
feat: real documentation links and UTM tagging on the Support tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ includes/
   PostType/BoardScribeCPT.php          CPT registration
   Admin/MetaBox.php                    Native meta box UI + save handling
   Admin/SettingsPage.php               Tabbed settings page (General / Shortcode Builder / Support); the Builder tab enqueues the React builder app
+  Helpers/Helpers.php                  UTM link builder for outbound equalizedigital.com links (edition + days_active reporting)
   REST/BoardScribeEndpoint.php      /edbs/v1/boardscribe/ REST route + query/row building
   Shortcode/BoardScribeShortcode.php Shortcode registration, asset enqueuing, instance config
   Block/BoardScribeBlock.php           Server-registered block wrapping the shortcode pipeline + editor preview
@@ -44,7 +45,7 @@ assets/css/boardscribe.css             Frontend styles
 assets/css/builder.css                 Admin Shortcode Builder tab layout (two-column, sticky preview)
 assets/css/settings.css                Settings page layout (sidebar + tabbed panel, BoardScribe brand colors)
 assets/images/logo.png                 BoardScribe logo shown in the settings sidebar header
-uninstall.php                         Opt-in data cleanup on plugin deletion
+uninstall.php                         Opt-in data cleanup on plugin deletion (edbs_settings, edbs_activation_date)
 docs/                                 Planning docs (market research, premium features, readiness checklist) — not user-facing
 tests/                                PHPUnit setup
 ```
@@ -70,6 +71,7 @@ Keep this list current when adding or removing hooks — it's the primary refere
 | `edbs_before_meta_box_fields` / `edbs_meta_fields` | action | `Admin/MetaBox.php` | Render additional meta box fields before/after the defaults. |
 | `edbs_after_agenda_url_field` / `edbs_after_minutes_url_field` | action | `partials/meta-box.php` | Fire immediately after the Agenda URL / Minutes URL field's own `<tr>`, so a plugin adding a field tightly coupled to one of those URLs (e.g. Pro's Document picker, which the URL field defers to) can render its row directly underneath it — `edbs_meta_fields` only fires once, after every default field. |
 | `edbs_save_meeting_meta` | action | `Admin/MetaBox.php` | Fires after the default meta fields are saved — save Pro's own meta here. |
+| `edbs_utm_query_args` | filter | `Helpers/Helpers.php` | Query parameters appended to outbound equalizedigital.com links by `Helpers::utm_link_builder()` (utm_source/medium/campaign/content plus php_version, platform, platform_version, software, software_version, days_active). `software` is `free`, `pro-unlicensed`, or `pro` — resolved by reading Pro's `edbs_pro_license_status` option directly, since free can't call `LicenseManager::is_licensed()`. **If Pro ever renames that option, this breaks silently**; Pro should then override `software` through this filter. |
 | `edbs_settings_fields` | action | `Admin/SettingsPage.php` | Add sections to the General tab's form outside the Settings API (e.g. license management). Fires inside the General tab only. |
 | `edbs_settings_tabs` | filter | `Admin/SettingsPage.php` | Register a settings-page tab. Filters the tab map (slug => `[ 'icon' => dashicons class, 'label' => string ]`); array order is display order. Core tabs: `general`, `builder`, `support`. Pro adds e.g. an `import` tab here (paired with the action below), replacing its old standalone `edbs-import` submenu. Pro enqueues its tab's own assets keyed off the `edbs_meeting_page_edbs-settings` hook + active `tab` query var (same pattern as the builder tab). |
 | `edbs_settings_tab_content_{$tab}` | action | `Admin/SettingsPage.php` | Renders the panel content for a non-core tab registered via `edbs_settings_tabs`. The dynamic portion is the tab slug (e.g. `edbs_settings_tab_content_import`). Only fires for tabs present in the filtered tab list. |

--- a/boardscribe.php
+++ b/boardscribe.php
@@ -64,6 +64,8 @@ require_once EDBS_DIR . 'vendor/autoload.php';
 // when the autoloader guard above just bailed.
 define( 'EDBS_VERSION', '1.0.0' );
 
+register_activation_hook( __FILE__, [ 'EqualizeDigital\BoardScribe\Plugin', 'activate' ] );
+
 // Boot the plugin.
 add_action(
 	'plugins_loaded',

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use EqualizeDigital\BoardScribe\Helpers\Helpers;
 use EqualizeDigital\BoardScribe\Plugin;
 use EqualizeDigital\BoardScribe\Shortcode\BoardScribeShortcode;
 use EqualizeDigital\BoardScribe\Shortcode\FieldRegistry;
@@ -441,6 +442,26 @@ class SettingsPage {
 	}
 
 	/**
+	 * Builds a UTM-tagged link for the Support tab.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url         Absolute URL, or a path relative to the BoardScribe site section.
+	 * @param string $utm_content Identifies which link on the tab was clicked.
+	 *
+	 * @return string
+	 */
+	private function support_url( string $url, string $utm_content ): string {
+		return Helpers::utm_link_builder(
+			$url,
+			[
+				'utm_campaign' => 'settings-support',
+				'utm_content'  => $utm_content,
+			]
+		);
+	}
+
+	/**
 	 * Renders the Support tab (documentation and contact links).
 	 *
 	 * @since 1.0.0
@@ -448,16 +469,42 @@ class SettingsPage {
 	 * @return void
 	 */
 	private function render_support_tab(): void {
-		// Placeholder links — swap for real BoardScribe documentation URLs.
 		$quick_links = [
-			__( 'Getting Started with BoardScribe', 'boardscribe' ),
-			__( 'Displaying Meetings with the Shortcode', 'boardscribe' ),
-			__( 'Using the BoardScribe Block', 'boardscribe' ),
-			__( 'Adding a Meeting', 'boardscribe' ),
-			__( 'Agenda and Minutes Links', 'boardscribe' ),
-			__( 'Is BoardScribe Accessible?', 'boardscribe' ),
-			__( 'BoardScribe Developer Guide', 'boardscribe' ),
-			__( 'BoardScribe Hooks Reference', 'boardscribe' ),
+			[
+				'url'         => '/documentation/downloading-and-installing-boardscribe/',
+				'label'       => __( 'Downloading and Installing BoardScribe', 'boardscribe' ),
+				'utm_content' => 'downloading-and-installing-boardscribe',
+			],
+			[
+				'url'         => '/documentation/boardscribe-settings/',
+				'label'       => __( 'BoardScribe Settings', 'boardscribe' ),
+				'utm_content' => 'boardscribe-settings',
+			],
+			[
+				'url'         => '/documentation/board-meetings-post-type/',
+				'label'       => __( 'Board Meetings Post Type', 'boardscribe' ),
+				'utm_content' => 'board-meetings-post-type',
+			],
+			[
+				'url'         => '/documentation/shortcode-builder/',
+				'label'       => __( 'Shortcode Builder', 'boardscribe' ),
+				'utm_content' => 'shortcode-builder',
+			],
+			[
+				'url'         => '/documentation/is-boardscribe-accessible/',
+				'label'       => __( 'Is BoardScribe accessible?', 'boardscribe' ),
+				'utm_content' => 'is-boardscribe-accessible',
+			],
+			[
+				'url'         => '/boardscribe-documentation/what-languages-is-boardscribe-available-in/',
+				'label'       => __( 'What languages is BoardScribe translated into?', 'boardscribe' ),
+				'utm_content' => 'what-languages-is-boardscribe-available-in',
+			],
+			[
+				'url'         => '/documentation/how-do-i-add-file-type-and-size-information-to-links/',
+				'label'       => __( 'How do I add file size and type information to links?', 'boardscribe' ),
+				'utm_content' => 'how-do-i-add-file-type-and-size-information-to-links',
+			],
 		];
 		?>
 		<div class="edbs-settings-panel-sub">
@@ -465,7 +512,7 @@ class SettingsPage {
 			<p class="edbs-settings-support-description">
 				<?php esc_html_e( 'Need help? Check out our documentation for step-by-step guides and feature walkthroughs.', 'boardscribe' ); ?>
 			</p>
-			<a class="button button-secondary" href="#" target="_blank" rel="noopener noreferrer">
+			<a class="button button-secondary" href="<?php echo esc_url( $this->support_url( '/documentation/', 'button-documentation' ) ); ?>" target="_blank" rel="noopener noreferrer">
 				<?php esc_html_e( 'View Documentation', 'boardscribe' ); ?>
 				<span class="screen-reader-text"><?php esc_html_e( '(opens in a new tab)', 'boardscribe' ); ?></span>
 			</a>
@@ -476,7 +523,7 @@ class SettingsPage {
 			<p class="edbs-settings-support-description">
 				<?php esc_html_e( 'Have questions or need help? Reach out to our support team.', 'boardscribe' ); ?>
 			</p>
-			<a class="button button-secondary" href="#" target="_blank" rel="noopener noreferrer">
+			<a class="button button-secondary" href="<?php echo esc_url( $this->support_url( 'https://my.equalizedigital.com/support/', 'button-support' ) ); ?>" target="_blank" rel="noopener noreferrer">
 				<?php esc_html_e( 'Contact Support', 'boardscribe' ); ?>
 				<span class="screen-reader-text"><?php esc_html_e( '(opens in a new tab)', 'boardscribe' ); ?></span>
 			</a>
@@ -485,10 +532,10 @@ class SettingsPage {
 		<div class="edbs-settings-panel-sub">
 			<h2><?php esc_html_e( 'Quick Links', 'boardscribe' ); ?></h2>
 			<ul class="edbs-settings-links-list">
-				<?php foreach ( $quick_links as $label ) : ?>
+				<?php foreach ( $quick_links as $link ) : ?>
 					<li>
-						<a href="#" target="_blank" rel="noopener noreferrer">
-							<?php echo esc_html( $label ); ?>
+						<a href="<?php echo esc_url( $this->support_url( $link['url'], $link['utm_content'] ) ); ?>" target="_blank" rel="noopener noreferrer">
+							<?php echo esc_html( $link['label'] ); ?>
 							<span class="screen-reader-text"><?php esc_html_e( '(opens in a new tab)', 'boardscribe' ); ?></span>
 						</a>
 					</li>

--- a/includes/Helpers/Helpers.php
+++ b/includes/Helpers/Helpers.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * BoardScribe helpers.
+ *
+ * Provides utility functions for the BoardScribe plugin.
+ *
+ * @package EqualizeDigital\BoardScribe\Helpers
+ * @since   1.0.0
+ */
+
+namespace EqualizeDigital\BoardScribe\Helpers;
+
+use EqualizeDigital\BoardScribe\Plugin;
+
+/**
+ * Helper functions for BoardScribe.
+ *
+ * @package EqualizeDigital\BoardScribe\Helpers
+ * @since   1.0.0
+ */
+class Helpers {
+
+	/**
+	 * Base URL that relative links are appended to.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	private const BASE_URL = 'https://equalizedigital.com/boardscribe/';
+
+	/**
+	 * Builds an equalizedigital.com URL with UTM and environment parameters.
+	 *
+	 * Mirrors the link-tagging used by our other plugins so outbound clicks from
+	 * the admin can be attributed to the plugin, the surface they came from, and
+	 * whether the site is running free or Pro.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url        Base URL. A relative value (anything not starting
+	 *                           with "http") is appended to the BoardScribe base URL.
+	 * @param array  $query_vars Parameters to add or override. Supports the standard
+	 *                           utm_source / utm_medium / utm_campaign / utm_content /
+	 *                           utm_term keys plus any other key-value pairs.
+	 *
+	 * @return string The URL with the parameters added.
+	 */
+	public static function utm_link_builder( string $url = '', array $query_vars = [] ): string {
+		// Relative URLs hang off the BoardScribe base URL.
+		if ( 0 !== strpos( $url, 'http' ) ) {
+			$url = self::BASE_URL . ltrim( $url, '/' );
+		}
+
+		$query_defaults = [
+			'utm_source'       => 'boardscribe',
+			'utm_medium'       => 'software',
+			'utm_campaign'     => 'wordpress-general',
+			'php_version'      => defined( 'PHP_VERSION' ) ? PHP_VERSION : '',
+			'platform'         => 'wordpress',
+			'platform_version' => get_bloginfo( 'version' ),
+			'software'         => self::get_software_edition(),
+			'software_version' => defined( 'EDBS_VERSION' ) ? EDBS_VERSION : '',
+			'days_active'      => self::get_days_active(),
+		];
+
+		// Caller-supplied values win, but never blank out a default.
+		$query_params = array_merge(
+			$query_defaults,
+			array_filter(
+				$query_vars,
+				function ( $value ) {
+					return ! empty( $value );
+				}
+			)
+		);
+
+		/**
+		 * Filters the query parameters appended to an outbound BoardScribe link.
+		 *
+		 * Pro uses this to report its own version alongside the free one.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array  $query_params The resolved parameters.
+		 * @param string $url          The URL being built.
+		 */
+		$query_params = apply_filters( 'edbs_utm_query_args', $query_params, $url );
+
+		// add_query_arg() encodes the values itself, so pass them raw.
+		return add_query_arg( $query_params, $url );
+	}
+
+	/**
+	 * Reports which edition of BoardScribe the site is running.
+	 *
+	 * Distinguishes an unlicensed Pro install from a licensed one: Pro can be
+	 * active with an expired or never-entered key, which is exactly the segment
+	 * worth telling apart in link attribution. Reads Pro's license status option
+	 * directly rather than calling `LicenseManager::is_licensed()`, since the
+	 * free plugin cannot depend on Pro's classes being loaded.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string One of "free", "pro-unlicensed", or "pro".
+	 */
+	private static function get_software_edition(): string {
+		if ( ! defined( 'EDBS_PRO_VERSION' ) ) {
+			return 'free';
+		}
+
+		return 'valid' === get_option( 'edbs_pro_license_status', '' ) ? 'pro' : 'pro-unlicensed';
+	}
+
+	/**
+	 * Returns how many whole days the plugin has been active on this site.
+	 *
+	 * Falls back to 0 when the activation date is missing or unparseable (an
+	 * install predating the activation hook, or one activated by dropping the
+	 * directory in place rather than through the plugins screen).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	private static function get_days_active(): int {
+		$activation_date = get_option( Plugin::ACTIVATION_DATE_OPTION, '' );
+
+		if ( ! is_string( $activation_date ) || '' === $activation_date ) {
+			return 0;
+		}
+
+		$activation_timestamp = strtotime( $activation_date . ' UTC' );
+
+		if ( false === $activation_timestamp ) {
+			return 0;
+		}
+
+		return max( 0, (int) floor( ( time() - $activation_timestamp ) / DAY_IN_SECONDS ) );
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -54,11 +54,35 @@ class Plugin {
 	}
 
 	/**
+	 * Option storing the date the plugin was first activated.
+	 */
+	const ACTIVATION_DATE_OPTION = 'edbs_activation_date';
+
+	/**
 	 * Private constructor — use get_instance().
 	 *
 	 * @since 1.0.0
 	 */
 	private function __construct() {}
+
+	/**
+	 * Runs on plugin activation.
+	 *
+	 * Records the first-activation date, used to report how long a site has
+	 * been running BoardScribe on outbound documentation links. The CPT is
+	 * registered with `public`/`rewrite`/`has_archive` all false, so there are
+	 * no rewrite rules to flush here.
+	 *
+	 * `add_option()` (not `update_option()`) so a deactivate/reactivate cycle
+	 * keeps the original date rather than restarting the clock.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function activate(): void {
+		add_option( self::ACTIVATION_DATE_OPTION, gmdate( 'Y-m-d H:i:s' ) );
+	}
 
 	/**
 	 * Boots the plugin. Hooked to plugins_loaded.

--- a/uninstall.php
+++ b/uninstall.php
@@ -35,3 +35,4 @@ foreach ( $edbs_meeting_post_ids as $edbs_meeting_post_id ) {
 
 // Delete plugin settings.
 delete_option( 'edbs_settings' );
+delete_option( 'edbs_activation_date' );


### PR DESCRIPTION
## Summary

The Support tab's quick links were placeholder labels pointing at `#`. This wires them to the published BoardScribe documentation pages ([per Amber's Basecamp message](https://3.basecamp.com/3579237/buckets/29333825/messages/10239453471)) and adds UTM tagging, ported from the pattern already used in [`equalizedigital/archivewp`](https://github.com/equalizedigital/archivewp).

## Changes

**`Helpers::utm_link_builder()`** (new `includes/Helpers/Helpers.php`) — mirrors ArchiveWP's helper. Relative paths resolve against `https://equalizedigital.com/boardscribe/`. Emits `utm_source`/`utm_medium`/`utm_campaign`/`utm_content` plus `php_version`, `platform`, `platform_version`, `software`, `software_version`, `days_active`.

**Support tab** — quick links now point at real pages, each with its own `utm_content` under a `settings-support` campaign. "View Documentation" and "Contact Support" got real destinations. Quick links became a list of arrays rather than a label-keyed map so two links can share a label.

**Activation date** — the free plugin had no lifecycle hooks, so `days_active` had nothing to read. Adds `Plugin::activate()` storing `edbs_activation_date`, plus `uninstall.php` cleanup.

Sample output:

```
https://equalizedigital.com/boardscribe/documentation/?utm_source=boardscribe
&utm_medium=software&utm_campaign=settings-support&php_version=8.2.1
&platform=wordpress&platform_version=6.8.1&software=free&software_version=1.0.0
&days_active=45&utm_content=button-documentation
```

## Decisions worth a look

**`software` reports three states, not two.** Pro exposes `LicenseManager::is_licensed()` reading the `edbs_pro_license_status` option. Free can't call Pro's classes, so it reads that option directly:

| Condition | `software` |
|---|---|
| `EDBS_PRO_VERSION` undefined | `free` |
| Pro active, status not `valid` | `pro-unlicensed` |
| Pro active, status `valid` | `pro` |

Splitting out `pro-unlicensed` keeps expired or never-entered keys from being counted as paying Pro installs. **This hardcodes a Pro option name into free with nothing to catch a rename** — noted in the CLAUDE.md hook table, and `edbs_utm_query_args` is the escape hatch if Pro needs to own the value.

**`days_active` survives reactivation.** ArchiveWP uses `update_option()` on activate and `delete_option()` on deactivate, so a deactivate/reactivate cycle resets it to 0. This uses `add_option()` and registers no deactivation hook, keeping the original install date. Say the word if you'd rather have strict parity.

**Dropped one link.** "Can I try it before putting it on my site?" is a pre-purchase question, and everyone seeing this tab has already installed the plugin.

No `flush_rewrite_rules()` in `activate()` — the CPT registers with `public`, `rewrite` and `has_archive` all false.

## Testing

`phpcs` and `parallel-lint` clean. URL construction verified under a shim across seven states — fresh install, just-activated, 45-days-active, post-reactivation, unlicensed Pro, licensed Pro, and an unparseable date (falls back to 0). Relative, absolute, and the irregular `/boardscribe-documentation/` path on the languages link all resolve correctly.

## Follow-ups

- Four pages from Amber's list have no URL yet ("How to get started with BoardScribe", "Accessibility Checker Compatibility", "BoardScribe Block", "BoardScribe Shortcode") and aren't included.
- Amber asked whether developer docs (hooks/filters) should be published. The material exists in `CLAUDE.md` and `docs/HOOK-CONTRACT-CHANGES.md`. The placeholder list this replaces had entries for a Developer Guide and Hooks Reference that don't exist on the site.
- "Downloading and Installing BoardScribe" is a weaker fit for this audience for the same reason as the dropped trial link, but kept since it may cover additional sites or Pro activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9MPN3ne1QVynSp1Uu6xGx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Support tab with updated documentation and contact links.
  - Quick links now include tracked URLs for improved support and resource navigation.
  - Plugin activation is recorded to support relevant account and support-link information.

- **Documentation**
  - Documented the new link-building behavior, activation-data cleanup, and available link customization options.

- **Bug Fixes**
  - Improved handling of link parameters while preserving existing custom values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->