### PR TITLE
fix: write dist zip atomically instead of straight to the release path

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -92,13 +92,22 @@ echo "Building plugin package for version: $VERSION"
 
 # Create final distributable zip. WordPress derives the install path from the
 # single top-level directory, so it has to be named exactly like the slug.
+# Built under a temp name and moved into place only once complete - zipping
+# straight to $FINAL_ZIP would leave a truncated file sitting at the real
+# release path if zip failed partway (disk full, permissions), indistinguishable
+# from a good build without re-checking. The temp file stays inside $DIST_DIR
+# so the final mv is a same-filesystem rename, not a copy.
 cd "$DIST_DIR" || exit 1
 FINAL_ZIP="${SLUG}-${VERSION}.zip"
-rm -f "$FINAL_ZIP"
-zip -r "$FINAL_ZIP" "$SLUG" > /dev/null || { echo "ERROR: zip failed"; exit 1; }
+TMP_ZIP=".${FINAL_ZIP}.tmp"
+rm -f "$TMP_ZIP"
+zip -r "$TMP_ZIP" "$SLUG" > /dev/null || { echo "ERROR: zip failed"; rm -f "$TMP_ZIP"; exit 1; }
 
 # Remove .po files (ignore errors if none)
-zip -d "$FINAL_ZIP" "${SLUG}/languages/*.po" > /dev/null || true
+zip -d "$TMP_ZIP" "${SLUG}/languages/*.po" > /dev/null || true
+
+rm -f "$FINAL_ZIP"
+mv "$TMP_ZIP" "$FINAL_ZIP"
 
 cd ..
 

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -103,11 +103,21 @@ TMP_ZIP=".${FINAL_ZIP}.tmp"
 rm -f "$TMP_ZIP"
 zip -r "$TMP_ZIP" "$SLUG" > /dev/null || { echo "ERROR: zip failed"; rm -f "$TMP_ZIP"; exit 1; }
 
-# Remove .po files (ignore errors if none)
-zip -d "$TMP_ZIP" "${SLUG}/languages/*.po" > /dev/null || true
+# Remove .po files. zip -d exits 12 for "nothing to do" (no .po files
+# matched) - that's fine, but any other nonzero status is a real failure
+# and must not let a zip that still contains .po files reach $FINAL_ZIP.
+zip -d "$TMP_ZIP" "${SLUG}/languages/*.po" > /dev/null
+ZIP_D_STATUS=$?
+if [ "$ZIP_D_STATUS" -ne 0 ] && [ "$ZIP_D_STATUS" -ne 12 ]; then
+  echo "ERROR: zip -d failed removing .po files (exit $ZIP_D_STATUS)" >&2
+  rm -f "$TMP_ZIP"
+  exit 1
+fi
 
-rm -f "$FINAL_ZIP"
-mv "$TMP_ZIP" "$FINAL_ZIP"
+# mv -f overwrites $FINAL_ZIP directly (a same-filesystem rename, so this
+# is atomic) instead of rm-then-mv, which would leave no zip at all at the
+# release path if the mv step failed after the rm already ran.
+mv -f "$TMP_ZIP" "$FINAL_ZIP" || { echo "ERROR: mv failed"; rm -f "$TMP_ZIP"; exit 1; }
 
 cd ..
 


### PR DESCRIPTION
## Summary
Follow-up to #56 (the real `scripts/dist.sh` packaging script). Ports the still-valid finding from #32 — which targeted the old manual packaging recipe in `SKILL.md` that #56 removed entirely, so #32 itself is superseded and being closed in favor of this.

- `scripts/dist.sh` zipped straight to `dist/<slug>-<version>.zip`. A mid-write failure (disk full, permissions, killed process) could leave a truncated file sitting at that exact release path, indistinguishable from a good build without re-verifying.
- Now zips into a temp file inside `dist/` and `mv`'s it into place only once `zip` (and the `.po` removal) have succeeded. A failure removes the temp file and leaves whatever was previously at the release path untouched.

PR #32's other finding — restoring Composer dev tooling on every exit path — doesn't need porting. `package.json`'s `dist` script already handles it more robustly: `... && ./scripts/dist.sh; rc=$?; composer install; exit $rc` restores dev tooling and preserves the real exit code regardless of which step failed, including `npm run build`, which a trap inside `dist.sh` itself could never have reached.

## Test plan
- [x] Happy-path `npm run dist` still produces a correct zip, dev tooling restored afterward
- [x] Forced-failure test (stubbed `zip` returning nonzero) confirmed the temp file is removed and a pre-existing final zip is left byte-for-byte untouched
- [x] `bash -n scripts/dist.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqysyMu4h1jfWoYhuNCQAJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release archive creation reliability by treating unexpected packaging failures as errors.
  * Prevented incomplete ZIP files from replacing existing archives.
  * Failed archive builds now clean up temporary files automatically, while expected cases with no removable files continue to complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->