### PR TITLE
test: add block InspectorControls regression coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,23 @@
+/* eslint-env node */
+/**
+ * Extends the default wp-scripts unit-test config (jsdom, babel-jest, no
+ * config needed for plain-JS ESM) with module mappings for the handful
+ * of WordPress packages this codebase only ever consumes as build-time
+ * externals (see webpack.config.js's externals map) - they resolve to
+ * wp.* globals in the browser, which don't exist under Jest, so tests
+ * that touch block/builder code need a stand-in. The element, hooks,
+ * i18n, and escape-html packages are real installed packages and need
+ * no mapping.
+ */
+const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
+
+module.exports = {
+	...baseConfig,
+	moduleNameMapper: {
+		...baseConfig.moduleNameMapper,
+		'^@wordpress/blocks$': '<rootDir>/tests/jest/test-utils/wp-mocks/blocks.js',
+		'^@wordpress/block-editor$': '<rootDir>/tests/jest/test-utils/wp-mocks/block-editor.js',
+		'^@wordpress/components$': '<rootDir>/tests/jest/test-utils/wp-mocks/components.js',
+		'^@wordpress/server-side-render$': '<rootDir>/tests/jest/test-utils/wp-mocks/server-side-render.js',
+	},
+};

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
 		"linting": "./vendor/bin/phpcs && npm run lint:js",
 		"lint:php": "./vendor/bin/phpcs",
 		"lint:php:fix": "./vendor/bin/phpcbf",
-		"lint:js": "wp-scripts lint-js src/js tests/jest webpack.config.js",
-		"lint:js:fix": "wp-scripts lint-js src/js tests/jest webpack.config.js --fix",
+		"lint:js": "wp-scripts lint-js src/js tests/jest webpack.config.js jest.config.js",
+		"lint:js:fix": "wp-scripts lint-js src/js tests/jest webpack.config.js jest.config.js --fix",
 		"test:js": "wp-scripts test-unit-js",
 		"test:php": "./scripts/setup-phpunit.sh",
 		"test:php:run": "docker compose exec phpunit vendor/bin/phpunit",
@@ -41,6 +41,7 @@
 		"*.js": "wp-scripts lint-js"
 	},
 	"devDependencies": {
+		"@wordpress/element": "^8.5.0",
 		"@wordpress/escape-html": "^3.50.0",
 		"@wordpress/eslint-plugin": "^17.5.0",
 		"@wordpress/i18n": "^6.23.0",

--- a/tests/jest/block/index.test.js
+++ b/tests/jest/block/index.test.js
@@ -1,0 +1,247 @@
+/**
+ * Regression test for the block's InspectorControls: every field the
+ * shared FieldRegistry (PHP) hands the editor via window.edbsBlockFieldRegistry
+ * must produce a visible control, whether it's a core field, a
+ * Pro/third-party field (edbs_shortcode_field_registry), or one of the
+ * hand-rendered special cases (template/postsPerPage/className) - this is
+ * exactly the gap a previous manual test run reported (postsPerPage
+ * missing from the block), which turned out not to reproduce on this
+ * codebase; this test pins that down so a real future regression fails
+ * loudly instead of needing another manual comparison.
+ *
+ * The block-editor `@wordpress` packages (blocks, block-editor, components,
+ * server-side-render) are mocked (see jest.config.js) - they're build-time
+ * externals (wp.* globals) in the real bundle, not installed packages
+ * Jest can resolve.
+ */
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { createElement } from '@wordpress/element';
+import { registerBlockType } from '@wordpress/blocks';
+
+// React 18's act() only suppresses its "not wrapped in act()" warnings
+// when this flag is set - there's no jsdom auto-detection for it.
+window.IS_REACT_ACT_ENVIRONMENT = true;
+
+// Every rendered container's root, keyed by container, so afterEach can
+// unmount via the same React 18 API each was created with.
+const roots = new WeakMap();
+
+const FIELD_FIXTURE = [
+	{
+		key: 'included_years',
+		attributeKey: 'includedYears',
+		configKey: 'includedYears',
+		type: 'text',
+		group: 'general',
+		label: 'Included Years',
+		default: '',
+		choices: null,
+		placeholder: '2023,2024',
+		description: null,
+	},
+	{
+		key: 'posts_per_page',
+		attributeKey: 'postsPerPage',
+		configKey: 'postsPerPage',
+		type: 'number_with_all',
+		group: 'general',
+		label: 'Posts Per Page',
+		default: 20,
+		choices: null,
+		placeholder: null,
+		description: null,
+	},
+	{
+		key: 'template',
+		attributeKey: 'template',
+		configKey: 'template',
+		type: 'select',
+		group: 'general',
+		label: 'Display Template',
+		default: '',
+		choices: { '': 'Table (default)' },
+		placeholder: null,
+		description: null,
+	},
+	{
+		key: 'equal_columns',
+		attributeKey: 'equalColumns',
+		configKey: 'equalColumns',
+		type: 'checkbox',
+		group: 'general',
+		label: 'Force all columns to the same width',
+		default: false,
+		choices: null,
+		placeholder: null,
+		description: null,
+	},
+	{
+		key: 'class',
+		attributeKey: 'className',
+		configKey: 'tableClass',
+		type: 'text',
+		group: 'general',
+		label: 'Custom CSS Class',
+		default: '',
+		choices: null,
+		placeholder: null,
+		description: null,
+	},
+	{
+		key: 'title_label',
+		attributeKey: 'titleLabel',
+		configKey: 'titleLabel',
+		type: 'text',
+		group: 'column_labels',
+		label: 'Title',
+		default: '',
+		choices: null,
+		placeholder: null,
+		description: null,
+	},
+	{
+		key: 'hide_title',
+		attributeKey: 'hideTitle',
+		configKey: 'hideTitle',
+		type: 'checkbox',
+		group: 'hide_columns',
+		label: 'Title',
+		default: false,
+		choices: null,
+		placeholder: null,
+		description: null,
+	},
+	// Simulates a Pro/third-party field appended via the
+	// edbs_shortcode_field_registry filter - proves it shows up with zero
+	// block-specific code, per the shared-registry design.
+	{
+		key: 'location_label',
+		attributeKey: 'locationLabel',
+		configKey: 'locationLabel',
+		type: 'text',
+		group: 'column_labels',
+		label: 'Location',
+		default: '',
+		choices: null,
+		placeholder: null,
+		description: null,
+	},
+];
+
+function defaultAttributes() {
+	const attributes = {};
+	FIELD_FIXTURE.forEach( ( field ) => {
+		attributes[ field.attributeKey ] = field.default;
+	} );
+	return attributes;
+}
+
+function renderEdit( attributes, setAttributes = jest.fn() ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+
+	const root = createRoot( container );
+	roots.set( container, root );
+
+	act( () => {
+		root.render(
+			// Rendered as a component (not called as a plain function) so
+			// React's hook dispatcher is actually active when edit() runs
+			// useRef/etc - calling it directly throws "Invalid hook call".
+			createElement( registerBlockType.mock.settings.edit, { attributes, setAttributes } ),
+		);
+	} );
+
+	return container;
+}
+
+function controlFor( container, controlType, label ) {
+	return container.querySelector(
+		`[data-control="${ controlType }"][data-label="${ label }"]`,
+	);
+}
+
+describe( 'BoardScribe block edit()', () => {
+	let container;
+
+	beforeAll( () => {
+		window.edbsBlockFieldRegistry = FIELD_FIXTURE;
+		// The block registers itself as a side effect of being imported.
+		require( '../../../src/js/block/index' );
+	} );
+
+	afterEach( () => {
+		if ( container ) {
+			act( () => {
+				roots.get( container )?.unmount();
+			} );
+			container.remove();
+			container = null;
+		}
+	} );
+
+	it( 'registers the equalize-digital/boardscribe block', () => {
+		expect( registerBlockType.mock.name ).toBe( 'equalize-digital/boardscribe' );
+		expect( typeof registerBlockType.mock.settings.edit ).toBe( 'function' );
+	} );
+
+	it( 'renders a control for every non-special-cased registry field', () => {
+		container = renderEdit( defaultAttributes() );
+
+		// Generic "general" group fields.
+		expect( controlFor( container, 'text', 'Included Years' ) ).not.toBeNull();
+		expect( controlFor( container, 'toggle', 'Force all columns to the same width' ) ).not.toBeNull();
+
+		// column_labels group, including a simulated Pro field - proves
+		// third-party registry additions need no block-specific code.
+		expect( controlFor( container, 'text', 'Title' ) ).not.toBeNull();
+		expect( controlFor( container, 'text', 'Location' ) ).not.toBeNull();
+
+		// hide_columns group - "Title" here is a checkbox, distinct from
+		// the "Title" text field in column_labels above.
+		expect( controlFor( container, 'toggle', 'Title' ) ).not.toBeNull();
+	} );
+
+	it( 'renders the Posts Per Page control (the field previously reported missing)', () => {
+		container = renderEdit( defaultAttributes() );
+
+		expect( controlFor( container, 'toggle', 'Show all meetings' ) ).not.toBeNull();
+		expect( controlFor( container, 'number', 'Records Per Page' ) ).not.toBeNull();
+	} );
+
+	it( 'hides the Records Per Page number field once "Show all meetings" is on', () => {
+		container = renderEdit( { ...defaultAttributes(), postsPerPage: -1 } );
+
+		expect( controlFor( container, 'toggle', 'Show all meetings' ) ).not.toBeNull();
+		expect( controlFor( container, 'number', 'Records Per Page' ) ).toBeNull();
+	} );
+
+	it( 'renders the template picker from the registry field, not a hand-maintained list', () => {
+		container = renderEdit( defaultAttributes() );
+
+		expect( controlFor( container, 'select', 'Display Template' ) ).not.toBeNull();
+	} );
+
+	it( 'renders no control at all for className - it uses the block\'s native Advanced panel field instead', () => {
+		container = renderEdit( defaultAttributes() );
+
+		expect( container.querySelector( '[data-label="Custom CSS Class"]' ) ).toBeNull();
+	} );
+
+	it( 'groups fields into panels matching the shortcode builder\'s groups, skipping empty ones', () => {
+		container = renderEdit( defaultAttributes() );
+
+		const panelTitles = Array.from( container.querySelectorAll( '[data-panel]' ) ).map(
+			( el ) => el.getAttribute( 'data-panel' ),
+		);
+
+		expect( panelTitles ).toEqual(
+			expect.arrayContaining( [ 'Display Settings', 'Column Labels', 'Hide Columns' ] ),
+		);
+		// The fixture has no link_labels/show_columns fields - those panels
+		// must not render at all (renderGenericFields() gates on group.length).
+		expect( panelTitles ).not.toContain( 'Link Labels' );
+		expect( panelTitles ).not.toContain( 'Show Columns' );
+	} );
+} );

--- a/tests/jest/test-utils/wp-mocks/block-editor.js
+++ b/tests/jest/test-utils/wp-mocks/block-editor.js
@@ -1,0 +1,16 @@
+/**
+ * Test-only stand-in for @wordpress/block-editor (see blocks.js mock for
+ * why this is mocked at all). Just enough to let the block's edit()
+ * render: InspectorControls passes its children through untouched (the
+ * real one portals them into the editor sidebar, which doesn't exist in
+ * a jsdom test), and useBlockProps returns an empty props object.
+ */
+import { Fragment, createElement } from '@wordpress/element';
+
+export function useBlockProps() {
+	return {};
+}
+
+export function InspectorControls( { children } ) {
+	return createElement( Fragment, null, children );
+}

--- a/tests/jest/test-utils/wp-mocks/blocks.js
+++ b/tests/jest/test-utils/wp-mocks/blocks.js
@@ -1,0 +1,19 @@
+/**
+ * Test-only stand-in for @wordpress/blocks, which isn't installed as a
+ * real package (it's resolved to the wp.blocks global at build time - see
+ * webpack.config.js's externals map). Jest has no such global, so this
+ * module is wired in via jest.config.js's moduleNameMapper instead.
+ *
+ * Capturing the registered settings on the function itself lets a test
+ * import the same mocked module and read back whatever the block under
+ * test last registered, without any extra test-only exports the real
+ * package doesn't have.
+ *
+ * @param {string} name     The block name.
+ * @param {Object} settings The block settings, including edit()/save().
+ * @return {Object} The settings, unchanged (matches the real API's return value).
+ */
+export function registerBlockType( name, settings ) {
+	registerBlockType.mock = { name, settings };
+	return settings;
+}

--- a/tests/jest/test-utils/wp-mocks/components.js
+++ b/tests/jest/test-utils/wp-mocks/components.js
@@ -1,0 +1,80 @@
+/**
+ * Test-only stand-in for @wordpress/components (see blocks.js mock for
+ * why this is mocked at all). Each control renders as a plain DOM node
+ * carrying data-control/data-label attributes so tests can find "the
+ * control for field X" without depending on the real component library's
+ * internal markup - only the props this codebase actually reads
+ * (label/value/checked/onChange/options/min) are wired up.
+ */
+import { createElement } from '@wordpress/element';
+
+export function PanelBody( { title, initialOpen, children } ) {
+	return createElement(
+		'section',
+		{ 'data-panel': title, 'data-initial-open': String( !! initialOpen ) },
+		children
+	);
+}
+
+export function ToggleControl( { label, checked, onChange, help } ) {
+	return createElement(
+		'label',
+		{ 'data-control': 'toggle', 'data-label': label, 'data-help': help || '' },
+		createElement( 'input', {
+			type: 'checkbox',
+			checked: !! checked,
+			onChange: ( event ) => onChange( event.target.checked ),
+		} )
+	);
+}
+
+export function SelectControl( { label, value, options, onChange, help } ) {
+	return createElement(
+		'label',
+		{ 'data-control': 'select', 'data-label': label, 'data-help': help || '' },
+		createElement(
+			'select',
+			{ value, onChange: ( event ) => onChange( event.target.value ) },
+			( options || [] ).map( ( option ) =>
+				createElement( 'option', { key: option.value, value: option.value }, option.label )
+			)
+		)
+	);
+}
+
+export function TextControl( { label, value, onChange, placeholder, help } ) {
+	return createElement(
+		'label',
+		{ 'data-control': 'text', 'data-label': label, 'data-help': help || '' },
+		createElement( 'input', {
+			type: 'text',
+			value: value || '',
+			placeholder: placeholder || '',
+			onChange: ( event ) => onChange( event.target.value ),
+		} )
+	);
+}
+
+export function TextareaControl( { label, value, onChange, help } ) {
+	return createElement(
+		'label',
+		{ 'data-control': 'textarea', 'data-label': label, 'data-help': help || '' },
+		createElement( 'textarea', {
+			value: value || '',
+			onChange: ( event ) => onChange( event.target.value ),
+		} )
+	);
+}
+
+export function __experimentalNumberControl( { label, value, onChange, min, help } ) {
+	return createElement(
+		'label',
+		{ 'data-control': 'number', 'data-label': label, 'data-help': help || '' },
+		createElement( 'input', {
+			type: 'number',
+			value: value ?? '',
+			min,
+			onChange: ( event ) => onChange( event.target.value ),
+		} )
+	);
+}

--- a/tests/jest/test-utils/wp-mocks/server-side-render.js
+++ b/tests/jest/test-utils/wp-mocks/server-side-render.js
@@ -1,0 +1,11 @@
+/**
+ * Test-only stand-in for @wordpress/server-side-render (see blocks.js
+ * mock for why this is mocked at all) - the real component performs a
+ * REST request the test environment can't serve, so this just renders a
+ * placeholder marking where it would appear.
+ */
+import { createElement } from '@wordpress/element';
+
+export default function ServerSideRender() {
+	return createElement( 'div', { 'data-testid': 'server-side-render' } );
+}


### PR DESCRIPTION
## What & why

Rescues unlanded work from the stale `william/pro-1240-1241-table-tabindex-focus` branch. That branch's actual fix (#58, the meetings-table tabindex/focus fix) already merged to `main`. Afterward a follow-up PR (#59) — a regression test for the block's InspectorControls sidebar — was stacked on top of that branch (per CodeRabbit's out-of-scope-changes check on #58) and merged *into it*, but nobody ever opened a PR bringing it back to `main`. The branch is otherwise just stale relative to everything that's since merged (dist-build work, doc cleanups, etc.) — this PR extracts only the real unlanded content and adapts it to the current test setup.

Adds a regression test for the block's InspectorControls sidebar: every field the shared FieldRegistry (PHP) hands the editor via `window.edbsBlockFieldRegistry` must produce a visible control, whether it's a core field, a Pro/third-party field, or a hand-rendered special case (`template`/`postsPerPage`/`className`). Direct guard for the "Posts Per Page missing from the block" report that prompted this test — confirmed not to currently reproduce, now pinned down.

## Adapting to the current pattern

The stale branch authored this against its own standalone `jest.config.js` + `@wordpress/element` devDependency, neither of which exist on current `main` (which just uses `wp-scripts test-unit-js` with no override config, per #58's own simpler focus/table tests). I verified the test content and its mocks still match `src/js/block/index.js`, `src/js/shared/generic-field-control.js`, and `FieldRegistry.php` byte-for-byte (field keys, group names, panel titles, `data-control` types) before porting — nothing needed rewriting there, only the scaffolding:

- Added a root `jest.config.js` layering `@wordpress/blocks`/`@wordpress/block-editor`/`@wordpress/components`/`@wordpress/server-side-render` mocks (they're build-time externals — `wp.*` globals — not real installed packages) onto `@wordpress/scripts`' default jest-unit config. `wp-scripts test-unit-js` picks this up automatically.
- Declared `@wordpress/element` as an explicit devDependency (imported directly by the mocks and the block source; was previously only present transitively).
- Added `jest.config.js` to the `lint:js`/`lint:js:fix` script args.

## Test plan
- [x] `npm run test:js` — 3 suites / 13 tests passing (2 existing + this new one)
- [x] `npm run lint:js` clean
- [x] `npm run build` compiles
- [x] `npm install` — no `package-lock.json` diff (the transitive `@wordpress/element` resolution already satisfied `^8.5.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqysyMu4h1jfWoYhuNCQAJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for block editor settings, including conditional controls, field grouping, class names, and block registration.
  * Improved test reliability with local mocks for WordPress editor, component, block, and server-rendering integrations.
* **Chores**
  * Added Jest configuration and included it in JavaScript linting.
  * Added the required WordPress element development package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->