### PR TITLE
fix: correct broken languages documentation link

### DIFF
--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -496,7 +496,7 @@ class SettingsPage {
 				'utm_content' => 'is-boardscribe-accessible',
 			],
 			[
-				'url'         => '/boardscribe-documentation/what-languages-is-boardscribe-available-in/',
+				'url'         => '/documentation/what-languages-is-boardscribe-available-in/',
 				'label'       => __( 'What languages is BoardScribe translated into?', 'boardscribe' ),
 				'utm_content' => 'what-languages-is-boardscribe-available-in',
 			],


### PR DESCRIPTION
## Summary

The Support tab's "What languages is BoardScribe translated into?" quick link returns **404**.

Every other documentation page lives under `/boardscribe/documentation/`, but this one entry came through as `/boardscribe/boardscribe-documentation/`. The page itself exists at the standard prefix, so this repoints the link rather than dropping it.

```diff
-'url' => '/boardscribe-documentation/what-languages-is-boardscribe-available-in/',
+'url' => '/documentation/what-languages-is-boardscribe-available-in/',
```

## Verification

Every Support tab link checked live, all 200:

| Status | Link |
|---|---|
| 200 | `/documentation/` (View Documentation button) |
| 200 | `/documentation/downloading-and-installing-boardscribe/` |
| 200 | `/documentation/boardscribe-settings/` |
| 200 | `/documentation/board-meetings-post-type/` |
| 200 | `/documentation/shortcode-builder/` |
| 200 | `/documentation/is-boardscribe-accessible/` |
| 200 | `/documentation/what-languages-is-boardscribe-available-in/` ← fixed |
| 200 | `/documentation/how-do-i-add-file-type-and-size-information-to-links/` |
| 200 | `my.equalizedigital.com/support/` (Contact Support button) |

`phpcs` and `parallel-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9MPN3ne1QVynSp1Uu6xGx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Support tab’s BoardScribe language translations quick link to point to the current documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->