### PR TITLE
Update screenshot descriptions to match new screenshots

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -211,9 +211,9 @@ No. This plugin uses native WordPress meta fields and requires no third-party pl
 == Screenshots ==
 
 1. Board meeting post type edit screen with fields for Meeting Date, Agenda URL, Minutes URL, and a check box to indicate if the meeting was not held.
-2. Board meeting tables output on the front end by fiscal year. Tables have columns for meeting title, date, view agenda link, and view minutes link. There is a meeting that has a month and year date format (rather than a ful date), which is marked as not held. Pagination buttons are below the table.
+2. Board meeting tables output on the front end by fiscal year. Tables have columns for meeting title, date, view agenda link, and view minutes link. There is a meeting that has a month and year date format (rather than a full date), which is marked as not held. Pagination buttons are below the table.
 3. Browser dev tools inspector open showing that view minutes links have an aria-label that appends the date to make links unique. Also shown in the code: title cells have a role of rowheader, and a polite aria-live container announces pagination changes.
-4. Mobile view of BoardScribe table: no horizontal scrolling and column headers remain visible.
+4. Mobile view of BoardScribe table: each meeting displays as a stacked card with TITLE, DATE, AGENDA, and MINUTES labels retained, instead of a horizontally scrolling table.
 5. Multiple Board Meetings blocks in the block editor with heading blocks. Each block has a unique style controlled by detailed options within the block settings in the right sidebar.
 6. BoardScribe Shortcode Builder shows a form for display settings at right and a generated shortcode at right with a copy button above a live preview.
 7. BoardScribe general settings showing an option to delete all BoardScribe meeting posts and plugin settings when BoardScribe is deleted.

--- a/readme.txt
+++ b/readme.txt
@@ -210,9 +210,13 @@ No. This plugin uses native WordPress meta fields and requires no third-party pl
 
 == Screenshots ==
 
-1. Accessible board meetings table with agenda and minutes links, displayed on the front end.
-2. Adding a board meeting (date, agenda URL, and minutes URL) in the WordPress admin.
-3. The Shortcode Builder generating a ready-to-paste meeting minutes shortcode.
+1. Board meeting post type edit screen with fields for Meeting Date, Agenda URL, Minutes URL, and a check box to indicate if the meeting was not held.
+2. Board meeting tables output on the front end by fiscal year. Tables have columns for meeting title, date, view agenda link, and view minutes link. There is a meeting that has a month and year date format (rather than a ful date), which is marked as not held. Pagination buttons are below the table.
+3. Browser dev tools inspector open showing that view minutes links have an aria-label that appends the date to make links unique. Also shown in the code: title cells have a role of rowheader, and a polite aria-live container announces pagination changes.
+4. Mobile view of BoardScribe table: no horizontal scrolling and column headers remain visible.
+5. Multiple Board Meetings blocks in the block editor with heading blocks. Each block has a unique style controlled by detailed options within the block settings in the right sidebar.
+6. BoardScribe Shortcode Builder shows a form for display settings at right and a generated shortcode at right with a copy button above a live preview.
+7. BoardScribe general settings showing an option to delete all BoardScribe meeting posts and plugin settings when BoardScribe is deleted.
 
 == Changelog ==
 


### PR DESCRIPTION
Updated screenshots: 
1. Board meeting post type edit screen with fields for Meeting Date, Agenda URL, Minutes URL, and a check box to indicate if the meeting was not held.
2. Board meeting tables output on the front end by fiscal year. Tables have columns for meeting title, date, view agenda link, and view minutes link. There is a meeting that has a month and year date format (rather than a ful date), which is marked as not held. Pagination buttons are below the table.
3. Browser dev tools inspector open showing that view minutes links have an aria-label that appends the date to make links unique. Also shown in the code: title cells have a role of rowheader, and a polite aria-live container announces pagination changes.
4. Mobile view of BoardScribe table: no horizontal scrolling and column headers remain visible.
5. Multiple Board Meetings blocks in the block editor with heading blocks. Each block has a unique style controlled by detailed options within the block settings in the right sidebar.
6. BoardScribe Shortcode Builder shows a form for display settings at right and a generated shortcode at right with a copy button above a live preview.
7. BoardScribe general settings showing an option to delete all BoardScribe meeting posts and plugin settings when BoardScribe is deleted.

## Files to include
<img width="1292" height="717" alt="screenshot-1" src="https://github.com/user-attachments/assets/7d611f39-aaf8-47c6-86bd-bcb57fb42521" />
<img width="1224" height="379" alt="screenshot-7" src="https://github.com/user-attachments/assets/27a5c760-33a1-4e8c-ba0a-c815024b89f1" />
<img width="1264" height="837" alt="screenshot-6" src="https://github.com/user-attachments/assets/0271a909-8c66-4840-bd4b-2940fe7ce025" />
<img width="1529" height="1197" alt="screenshot-5" src="https://github.com/user-attachments/assets/65e6d87f-f5b6-4441-959b-133675c00f94" />
<img width="411" height="860" alt="screenshot-4" src="https://github.com/user-attachments/assets/32191a9e-aa1b-4f23-b7b4-828ab6c7271d" />
<img width="1715" height="818" alt="screenshot-3" src="https://github.com/user-attachments/assets/21e14025-bd4a-491b-a9ce-905512c17c4e" />
<img width="1236" height="960" alt="screenshot-2" src="https://github.com/user-attachments/assets/ad6898cb-1377-45e5-bfa9-d5080f41fb80" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Screenshots section with detailed captions covering meeting edits, fiscal-year tables, accessibility markup, mobile views, block settings, the Shortcode Builder, and data deletion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->