### PR TITLE
Add project Claude Code settings to suppress attribution in commits/PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ docs-local
 
 # Client data files must never be committed
 docs/*.csv
+
+# Claude Code (personal, not committed — .claude/settings.json is shared)
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary
Adds a committed `.claude/settings.json` that turns off Claude Code's automatic attribution for anyone running it against this repo.

By default Claude Code appends:
- `Co-Authored-By: Claude ...` and `Claude-Session: <url>` trailers on commits
- a `_Generated by Claude Code_` footer on PR descriptions

## Why project settings rather than personal ones
Setting this in each person's `~/.claude/settings.json` leaves two gaps:

- new contributors get the default behavior until they know to change it
- cloud sessions run in a provisioned container that never sees a local user settings file

Project settings are read from the repo checkout, so committing them covers both cases in one place.

## Changes
- **`.claude/settings.json`** (new) — `attribution: { commit: "", pr: "", sessionUrl: false }`. Deliberately scoped to attribution only; permissions, hooks and model choice are personal and stay out of the shared file.
- **`.gitignore`** — ignore `.claude/settings.local.json` and `.claude/worktrees/`, so personal permission allowlists don't get committed by accident.

## Notes
`attribution` is not one of the settings keys restricted to user/managed scope, so project scope should be honored. Worth a spot-check on the first cloud-session commit after this merges. Local terminal and desktop sessions are confirmed to read it.

No functional changes; nothing shipped in the build.

Matches equalizedigital/accessibility-checker-pro#848.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project configuration for development tooling.
  * Added ignore rules to prevent personal settings and temporary worktree files from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->