### PR TITLE
fix: exclude CSV importer literal tokens from translation

### DIFF
--- a/includes/Import/CsvImporter.php
+++ b/includes/Import/CsvImporter.php
@@ -82,11 +82,19 @@ class CsvImporter {
 			],
 			'not_held'     => [
 				'required' => false,
-				'notes'    => __( 'yes / 1 / true', 'boardscribe' ),
+				'notes'    => sprintf(
+					/* translators: %s: the literal CSV values accepted ("yes / 1 / true") — these are fixed tokens the importer checks for, not to be translated. */
+					__( 'Accepted values: %s', 'boardscribe' ),
+					'yes / 1 / true'
+				),
 			],
 			'publish_date' => [
 				'required' => false,
-				'notes'    => __( 'Any recognizable date or date/time (e.g. 2024-03-15, 2024-03-15 14:30:00, or 2024-03-15T14:30:00-05:00). Sets the actual WordPress publish date instead of the moment of import — use this to backdate historical meetings. Does not affect the meeting date/sort order above.', 'boardscribe' ),
+				'notes'    => sprintf(
+					/* translators: %s: example date/time formats — these are literal examples, not to be translated. */
+					__( 'Any recognizable date or date/time (e.g. %s). Sets the actual WordPress publish date instead of the moment of import — use this to backdate historical meetings. Does not affect the meeting date/sort order above.', 'boardscribe' ),
+					'2024-03-15, 2024-03-15 14:30:00, or 2024-03-15T14:30:00-05:00'
+				),
 			],
 		];
 


### PR DESCRIPTION
## Summary
- CodeRabbit flagged (on #100) that several `.po` files had localized the `not_held` and `publish_date` column help text in `CsvImporter::columns()` — but that text embeds the literal values `CsvImporter::process_csv()` actually checks for (`yes / 1 / true`) and literal example date formats, so a translated string no longer matches what the importer accepts.
- Fix at the source instead of patching individual `.po` files: move those literal tokens out of the `__()` string and into `sprintf()` placeholders, so only the surrounding sentence is translatable and the literal values always render unchanged regardless of locale.
- Next `.pot`/`.po` regeneration will pick this up automatically; no manual `languages/` edits needed.

## Why
Translating `.po` files by hand or CI can't reliably keep functional literal values in help text intact — excluding them from the translatable string is the durable fix.

## Test plan
- [x] `php -l includes/Import/CsvImporter.php`
- [x] `./vendor/bin/phpcs includes/Import/CsvImporter.php` — clean
- [ ] View the Import tab's column-reference table and confirm the `not_held` and `publish_date` notes still read correctly in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AWkD9xpTdTpBJXScVTuZo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved CSV column documentation for `not_held` and `publish_date`.
  - Clarified accepted values and publish-date behavior with translatable guidance and fixed examples.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->