### PR TITLE
feat: forward order param in default meetings request builder

### DIFF
--- a/src/js/defaults/request.js
+++ b/src/js/defaults/request.js
@@ -28,6 +28,7 @@ export function defaultBuildRequestUrl( instanceCfg, page ) {
 	url.searchParams.set( 'agenda_link_label', instanceCfg.agendaLinkLabel || '' );
 	url.searchParams.set( 'minutes_link_label', instanceCfg.minutesLinkLabel || '' );
 	url.searchParams.set( 'category', instanceCfg.category || '' );
+	url.searchParams.set( 'order', instanceCfg.order || '' );
 	url.searchParams.set( 'page', page );
 	return url.toString();
 }


### PR DESCRIPTION
## Summary

Forwards `instanceCfg.order` in `defaultBuildRequestUrl()` so a chosen sort order reaches the REST endpoint — mirroring the existing `category` forwarding line one above it.

The `order` field itself is registered **by the Pro plugin** (`boardscribe-pro`, paired branch of the same name — merge this PR first). When unset, the param is empty and the endpoint ignores it, keeping its hardcoded DESC (newest-first) default — zero behavior change for the free plugin alone.

## Why Pro-only

Sort order is a Pro feature (see the paired Pro PR). The free plugin only gains the mechanical URL-forwarding line, exactly like `category` — no free UI, no free shortcode attribute.

- Paired with: equalizedigital/boardscribe-pro (branch `feat/pro-1291-order-field-forwarding`)
- Linear: PRO-1291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - REST requests now include the configured meeting order, ensuring results follow the selected ordering preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->