### PR TITLE
feat(PRO-1290): forward date_scope param in default meetings request builder

### DIFF
--- a/src/js/defaults/request.js
+++ b/src/js/defaults/request.js
@@ -22,6 +22,7 @@ export function defaultBuildRequestUrl( instanceCfg, page ) {
 	url.searchParams.set( 'included_years', instanceCfg.includedYears || '' );
 	url.searchParams.set( 'start_date', instanceCfg.startDate || '' );
 	url.searchParams.set( 'end_date', instanceCfg.endDate || '' );
+	url.searchParams.set( 'date_scope', instanceCfg.dateScope || '' );
 	url.searchParams.set( 'held_date_format', instanceCfg.heldDateFormat || 'l, F j, Y' );
 	url.searchParams.set( 'not_held_date_format', instanceCfg.notHeldDateFormat || 'F Y' );
 	url.searchParams.set( 'posts_per_page', instanceCfg.postsPerPage || 20 );


### PR DESCRIPTION
## Summary

Paired free-side plumbing for [PRO-1290](https://linear.app/equalize-digital/issue/PRO-1290) (upcoming/past date scope option, Pro feature).

The Pro plugin registers a `date_scope` field (all/upcoming/past) on the field registry; the default request builder must forward it to the REST endpoint, which resolves the scope against the current date. Mirrors the `order` forwarding precedent ([#107](https://github.com/equalizedigital/boardscribe/pull/107)).

Pro half: equalizedigital/boardscribe-pro #49.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Meeting request URLs now include the configured date scope, ensuring results are filtered according to the selected date range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->