### PR TITLE
feat(PRO-1290): add an upcoming/past date scope option to the meetings list

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -19,6 +19,7 @@ use EqualizeDigital\BoardScribe\PostType\BoardScribeCPT;
 use EqualizeDigital\BoardScribe\REST\BoardScribeEndpoint;
 use EqualizeDigital\BoardScribe\Shortcode\FieldRegistry;
 use EqualizeDigital\BoardScribe\Shortcode\BoardScribeShortcode;
+use EqualizeDigital\BoardScribe\Shortcode\MeetingDateScope;
 
 /**
  * Singleton plugin bootstrap. Wires all components together.
@@ -107,6 +108,7 @@ class Plugin {
 		( new BoardScribeShortcode() )->register();
 		( new BoardScribeBlock() )->register();
 		( new CsvImporter() )->register();
+		( new MeetingDateScope() )->register();
 
 		add_filter(
 			'edac_fix_file_size_and_type_additional_filters',

--- a/includes/Shortcode/MeetingDateScope.php
+++ b/includes/Shortcode/MeetingDateScope.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Upcoming/past date scope for the meetings shortcode/block/REST endpoint.
+ *
+ * @package EqualizeDigital\BoardScribe
+ */
+
+namespace EqualizeDigital\BoardScribe\Shortcode;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds an upcoming/past date-scope option to the meetings shortcode,
+ * block and REST endpoint.
+ *
+ * The endpoint only accepts literal start_date/end_date strings, so
+ * "from today forward" cannot be expressed without hand-editing the
+ * date every month. This registers a `date_scope` field (all/upcoming/
+ * past, default all) on the field registry, which surfaces it as a
+ * shortcode attribute, block control and builder field, and translates
+ * the chosen scope into a date-bounds meta query on the endpoint's
+ * WP_Query args via edbs_rest_query_args.
+ *
+ * @since x.x.x
+ */
+class MeetingDateScope {
+
+	/**
+	 * The field key registered on edbs_shortcode_field_registry.
+	 *
+	 * @var string
+	 */
+	const FIELD_KEY = 'date_scope';
+
+	/**
+	 * Hooks the date-scope field and REST arg into the field registry and
+	 * REST endpoint. Registered from Plugin::boot().
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter( 'edbs_shortcode_field_registry', [ $this, 'add_field' ] );
+		add_filter( 'edbs_rest_query_args', [ $this, 'apply_date_scope' ], 10, 2 );
+	}
+
+	/**
+	 * Adds the `date_scope` field descriptor to the field registry.
+	 *
+	 * The registry drives the shortcode attribute list, the instance config,
+	 * the Gutenberg block attribute + sidebar control, and the shortcode
+	 * builder UI. rest_arg is true so the endpoint can read it off the
+	 * request; apply_date_scope() whitelists the scope before it ever
+	 * touches the query.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $fields Field descriptors contributed by earlier-priority callbacks.
+	 * @return array
+	 */
+	public function add_field( array $fields ): array {
+		$fields[] = [
+			'key'         => self::FIELD_KEY,
+			'type'        => FieldRegistry::TYPE_SELECT,
+			'group'       => 'general',
+			'label'       => __( 'Date scope', 'boardscribe' ),
+			'description' => __( 'All meetings is the full archive. Upcoming shows only meetings from today onward; Past shows only meetings already held.', 'boardscribe' ),
+			'default'     => 'all',
+			'choices'     => [
+				'all'      => __( 'All meetings', 'boardscribe' ),
+				'upcoming' => __( 'Upcoming meetings', 'boardscribe' ),
+				'past'     => __( 'Past meetings', 'boardscribe' ),
+			],
+			'rest_arg'    => true,
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Applies the requested date scope to the endpoint's WP_Query args.
+	 *
+	 * Upcoming resolves to meetings held from today onward (date >= today),
+	 * past to meetings held before today (date < today), compared as dates
+	 * against the edbs_meeting_date meta in the site's own timezone.
+	 *
+	 * An explicit start_date/end_date on the request always takes priority
+	 * over the scope, matching how the endpoint already lets an explicit
+	 * range override included_years. Anything other than a bare
+	 * 'upcoming'/'past' scope (including the 'all' default and an absent
+	 * param) leaves the args untouched.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array            $args    The WP_Query args.
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return array
+	 */
+	public function apply_date_scope( array $args, \WP_REST_Request $request ): array {
+		$scope = $request->get_param( self::FIELD_KEY );
+
+		if ( 'upcoming' !== $scope && 'past' !== $scope ) {
+			return $args;
+		}
+
+		if ( $request->get_param( 'start_date' ) || $request->get_param( 'end_date' ) ) {
+			return $args;
+		}
+
+		if ( ! isset( $args['meta_query'] ) || ! is_array( $args['meta_query'] ) ) {
+			$args['meta_query'] = [ 'relation' => 'AND' ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- required to restrict meetings to the requested date scope.
+		}
+
+		$args['meta_query'][] = [
+			'key'     => 'edbs_meeting_date',
+			'value'   => wp_date( 'Y-m-d' ),
+			'compare' => 'upcoming' === $scope ? '>=' : '<',
+			'type'    => 'DATE',
+		];
+
+		return $args;
+	}
+}

--- a/tests/phpunit/MeetingDateScopeTest.php
+++ b/tests/phpunit/MeetingDateScopeTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Tests for MeetingDateScope field registration and REST scope filtering.
+ *
+ * @package EqualizeDigital\BoardScribe
+ */
+
+use EqualizeDigital\BoardScribe\Shortcode\MeetingDateScope;
+use WP_REST_Request;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * add_field() is a pure array transform hooked onto the free plugin's
+ * edbs_shortcode_field_registry filter; apply_date_scope() transforms the
+ * WP_Query args from a REST request param. Both are tested directly,
+ * since the free plugin isn't loaded in this test environment.
+ */
+class MeetingDateScopeTest extends TestCase {
+
+	/**
+	 * Adds exactly one "date_scope" descriptor with all/upcoming/past choices.
+	 */
+	public function test_adds_the_date_scope_field(): void {
+		$fields = ( new MeetingDateScope() )->add_field( [] );
+		$scope  = end( $fields );
+
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'date_scope', $scope['key'] );
+		$this->assertSame( 'select', $scope['type'] );
+		$this->assertSame( 'general', $scope['group'] );
+		$this->assertSame( 'all', $scope['default'] );
+		$this->assertTrue( $scope['rest_arg'] );
+		$this->assertArrayHasKey( 'all', $scope['choices'] );
+		$this->assertArrayHasKey( 'upcoming', $scope['choices'] );
+		$this->assertArrayHasKey( 'past', $scope['choices'] );
+	}
+
+	/**
+	 * Existing registry entries are preserved, not replaced.
+	 */
+	public function test_preserves_existing_fields(): void {
+		$existing = [ [ 'key' => 'included_years', 'type' => 'text' ] ];
+		$fields   = ( new MeetingDateScope() )->add_field( $existing );
+
+		$this->assertSame( 'included_years', $fields[0]['key'] );
+		$this->assertCount( 2, $fields );
+	}
+
+	/**
+	 * date_scope=upcoming appends a >= today meta clause on the meeting date.
+	 */
+	public function test_upcoming_restricts_to_today_or_later(): void {
+		$request = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$request->set_param( 'date_scope', 'upcoming' );
+
+		$args   = [ 'meta_query' => [ 'relation' => 'AND' ] ];
+		$result = ( new MeetingDateScope() )->apply_date_scope( $args, $request );
+		$clause = end( $result['meta_query'] );
+
+		$this->assertSame( 'edbs_meeting_date', $clause['key'] );
+		$this->assertSame( wp_date( 'Y-m-d' ), $clause['value'] );
+		$this->assertSame( '>=', $clause['compare'] );
+		$this->assertSame( 'DATE', $clause['type'] );
+	}
+
+	/**
+	 * date_scope=past appends a < today meta clause on the meeting date.
+	 */
+	public function test_past_restricts_to_before_today(): void {
+		$request = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$request->set_param( 'date_scope', 'past' );
+
+		$args   = [ 'meta_query' => [ 'relation' => 'AND' ] ];
+		$result = ( new MeetingDateScope() )->apply_date_scope( $args, $request );
+		$clause = end( $result['meta_query'] );
+
+		$this->assertSame( 'edbs_meeting_date', $clause['key'] );
+		$this->assertSame( wp_date( 'Y-m-d' ), $clause['value'] );
+		$this->assertSame( '<', $clause['compare'] );
+		$this->assertSame( 'DATE', $clause['type'] );
+	}
+
+	/**
+	 * A missing scope or the 'all' default leaves the args untouched.
+	 */
+	public function test_all_or_missing_scope_leaves_args_unchanged(): void {
+		$original = [ 'meta_query' => [ 'relation' => 'AND' ] ];
+
+		$request  = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$no_param = ( new MeetingDateScope() )->apply_date_scope( $original, $request );
+		$this->assertSame( $original, $no_param );
+
+		$all_request = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$all_request->set_param( 'date_scope', 'all' );
+		$all = ( new MeetingDateScope() )->apply_date_scope( $original, $all_request );
+		$this->assertSame( $original, $all );
+	}
+
+	/**
+	 * An unrecognized scope value is ignored rather than queryed against.
+	 */
+	public function test_unknown_scope_is_ignored(): void {
+		$original = [ 'meta_query' => [ 'relation' => 'AND' ] ];
+
+		$request = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$request->set_param( 'date_scope', 'random' );
+
+		$result = ( new MeetingDateScope() )->apply_date_scope( $original, $request );
+		$this->assertSame( $original, $result );
+	}
+
+	/**
+	 * An explicit start_date/end_date takes priority over the scope,
+	 * matching how the free endpoint lets an explicit range override
+	 * included_years.
+	 */
+	public function test_explicit_dates_take_priority_over_scope(): void {
+		$original = [ 'meta_query' => [ 'relation' => 'AND' ] ];
+
+		$request = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$request->set_param( 'date_scope', 'upcoming' );
+		$request->set_param( 'start_date', '2026-01-01' );
+
+		$result = ( new MeetingDateScope() )->apply_date_scope( $original, $request );
+		$this->assertSame( $original, $result );
+	}
+
+	/**
+	 * A scope applied to args with no meta_query yet creates one rather
+	 * than crashing, so the clause always has an AND relation to join.
+	 */
+	public function test_creates_meta_query_when_absent(): void {
+		$request = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$request->set_param( 'date_scope', 'past' );
+
+		$result = ( new MeetingDateScope() )->apply_date_scope( [], $request );
+
+		$this->assertArrayHasKey( 'meta_query', $result );
+		$this->assertSame( 'AND', $result['meta_query']['relation'] );
+		$this->assertCount( 2, $result['meta_query'] );
+	}
+
+	/**
+	 * register() wires the field onto edbs_shortcode_field_registry and
+	 * the date filter onto edbs_rest_query_args, so the free plugin's
+	 * machinery picks both up. Filters are removed again afterwards to
+	 * avoid leaking the callbacks into later tests.
+	 */
+	public function test_register_wires_both_hooks(): void {
+		$component = new MeetingDateScope();
+		$component->register();
+
+		$fields = apply_filters( 'edbs_shortcode_field_registry', [] );
+		$keys   = wp_list_pluck( $fields, 'key' );
+		$this->assertContains( 'date_scope', $keys );
+
+		$request = new WP_REST_Request( 'GET', '/edbs/v1/boardscribe/' );
+		$request->set_param( 'date_scope', 'upcoming' );
+		$result = apply_filters( 'edbs_rest_query_args', [ 'meta_query' => [ 'relation' => 'AND' ] ], $request );
+		$clause = end( $result['meta_query'] );
+		$this->assertSame( 'edbs_meeting_date', $clause['key'] );
+		$this->assertSame( '>=', $clause['compare'] );
+
+		remove_filter( 'edbs_shortcode_field_registry', [ $component, 'add_field' ] );
+		remove_filter( 'edbs_rest_query_args', [ $component, 'apply_date_scope' ] );
+	}
+}


### PR DESCRIPTION
## Summary
- Moves the date-scope feature from an unmerged Pro branch (PRO-1290, boardscribe-pro#49, now closed) into the free plugin, revisiting an earlier decision to keep it in Pro.
- The card itself already said this belongs in free (shortcode/block/REST endpoint all live here), and the driving use case — Rockford Township replacing The Events Calendar with an upcoming-meetings list — is a free-tier adoption story. It's also a structural twin of `MeetingSort` (#110), which landed in free for the same reason; keeping one free and gating the other would be an odd split.
- Straight port with license gating dropped (no licensing in free): registers a `date_scope` field (all/upcoming/past, default all) on the field registry, translated into a date-bounds meta query via `edbs_rest_query_args`. An explicit `start_date`/`end_date` still takes priority, matching how it already overrides `included_years`.

**Depends on #109** to actually reach the endpoint/front end, same as `MeetingSort` (#110).

## Test plan
- [x] `npm run test:php:run` — 133/133 PHPUnit tests pass (124 existing + 9 new for `MeetingDateScope`)
- [x] `./vendor/bin/phpcs` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a date scope option for meeting listings across shortcodes, blocks, builders, and REST requests.
  * Filter meetings by **Upcoming**, **Past**, or **All** dates.
  * Existing start-date and end-date filters take precedence when provided.

* **Tests**
  * Added coverage for date-scope filtering, field registration, date precedence, invalid values, and compatibility with existing query options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->