### PR TITLE
docs: require Linear gitBranchName for tracked work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,5 +148,5 @@ composer generate-hooks-docs        # regenerate docs/hooks.md (tools/generate-h
 - **Commits should be small and atomic** — each commit covers one minimal, self-contained chunk of related changes. Prefer several small commits within a PR over one large one; it keeps review and `git blame`/history useful even when the PR itself bundles a few related fixes.
 - **Use Conventional Commits style wherever possible** (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`, etc.) for commit subject lines.
 - **Always wait for review comments — including AI reviewers (CodeRabbit)** — before considering a PR done or merging. Don't skim past a "pending"/"in progress" AI review status. When findings land, surface them for discussion before fixing anything.
-- CodeRabbit auto-reviews PRs on this repo. (Gemini Code Assist previously also reviewed here but is no longer in use.)
+- CodeRabbit auto-reviews PRs on this repo.
 - When replying to review threads, reference the specific commit hash that addressed the finding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,9 @@ composer generate-hooks-docs        # regenerate docs/hooks.md (tools/generate-h
 
 - **One PR per logical change** — don't bundle unrelated fixes together.
 - Two long-lived branches: `develop` (active development, target most feature/fix PRs here) and `main` (stable/release branch, matches what's tagged for WordPress.org). Branch off `develop` for normal work; the `backport-to-develop` workflow auto-opens a PR to reconcile anything merged directly into `main`.
+- **Branch names for work tracked in Linear must match the issue's `gitBranchName`** (fetch it via the Linear issue, e.g. `steve/pro-1206-add-admin-columns`), not an ad-hoc description of the task — even when a session/task runner has already assigned a different branch name, check Linear first and use its slug instead.
 - **Commits should be small and atomic** — each commit covers one minimal, self-contained chunk of related changes. Prefer several small commits within a PR over one large one; it keeps review and `git blame`/history useful even when the PR itself bundles a few related fixes.
 - **Use Conventional Commits style wherever possible** (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`, etc.) for commit subject lines.
-- **Always wait for review comments — including AI reviewers (CodeRabbit, Gemini Code Assist)** — before considering a PR done or merging. Don't skim past a "pending"/"in progress" AI review status. When findings land, surface them for discussion before fixing anything.
-- CodeRabbit and Gemini Code Assist both auto-review PRs on this repo; expect both, not just one.
+- **Always wait for review comments — including AI reviewers (CodeRabbit)** — before considering a PR done or merging. Don't skim past a "pending"/"in progress" AI review status. When findings land, surface them for discussion before fixing anything.
+- CodeRabbit auto-reviews PRs on this repo. (Gemini Code Assist previously also reviewed here but is no longer in use.)
 - When replying to review threads, reference the specific commit hash that addressed the finding.


### PR DESCRIPTION
## Summary

- The admin-columns work (#105) landed on a session-assigned branch name (`claude/plugin-admin-columns-2z9cky`) instead of the Linear issue's canonical slug (`steve/pro-1206-add-admin-columns`), caught only after both PRs were already open, reviewed, and merged. Documents the check in the Workflow section so it happens before branching next time.
- Also drops the Gemini Code Assist mentions from the review workflow bullets — it's no longer used on this repo, CodeRabbit only.

## Test plan

Documentation-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKSWYFUeV444To6MdG2inL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKSWYFUeV444To6MdG2inL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution workflow guidance to clarify branch naming, commit practices, and review expectations.
  * Branch naming guidance now requires Linear issue slugs.
  * Removed references to Gemini Code Assist from the workflow documentation.
  * These updates provide clearer, more consistent instructions for contributing and reviewing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->