### PR TITLE
Add option to open agenda/minutes links in a new window

### DIFF
--- a/includes/Block/BoardScribeBlock.php
+++ b/includes/Block/BoardScribeBlock.php
@@ -350,10 +350,11 @@ class BoardScribeBlock {
 
 		$endpoint    = new BoardScribeEndpoint();
 		$format_args = [
-			'held_date_format'     => $attributes['heldDateFormat'] ?? 'l, F j, Y',
-			'not_held_date_format' => $attributes['notHeldDateFormat'] ?? 'F Y',
-			'agenda_link_label'    => $attributes['agendaLinkLabel'] ?? '',
-			'minutes_link_label'   => $attributes['minutesLinkLabel'] ?? '',
+			'held_date_format'      => $attributes['heldDateFormat'] ?? 'l, F j, Y',
+			'not_held_date_format'  => $attributes['notHeldDateFormat'] ?? 'F Y',
+			'agenda_link_label'     => $attributes['agendaLinkLabel'] ?? '',
+			'minutes_link_label'    => $attributes['minutesLinkLabel'] ?? '',
+			'open_links_new_window' => filter_var( $attributes['openLinksNewWindow'] ?? false, FILTER_VALIDATE_BOOLEAN ),
 		];
 
 		$rows = array_map(

--- a/includes/REST/BoardScribeEndpoint.php
+++ b/includes/REST/BoardScribeEndpoint.php
@@ -104,15 +104,16 @@ class BoardScribeEndpoint {
 	 * @return \WP_REST_Response
 	 */
 	public function get_meetings( \WP_REST_Request $request ): \WP_REST_Response {
-		$page                 = $request->get_param( 'page' );
-		$posts_per_page       = $request->get_param( 'posts_per_page' );
-		$held_date_format     = $request->get_param( 'held_date_format' );
-		$not_held_date_format = $request->get_param( 'not_held_date_format' );
-		$included_years       = $request->get_param( 'included_years' );
-		$start_date           = $request->get_param( 'start_date' );
-		$end_date             = $request->get_param( 'end_date' );
-		$agenda_link_label    = $request->get_param( 'agenda_link_label' ) ? $request->get_param( 'agenda_link_label' ) : __( 'View Agenda', 'boardscribe' );
-		$minutes_link_label   = $request->get_param( 'minutes_link_label' ) ? $request->get_param( 'minutes_link_label' ) : __( 'View Minutes', 'boardscribe' );
+		$page                  = $request->get_param( 'page' );
+		$posts_per_page        = $request->get_param( 'posts_per_page' );
+		$held_date_format      = $request->get_param( 'held_date_format' );
+		$not_held_date_format  = $request->get_param( 'not_held_date_format' );
+		$included_years        = $request->get_param( 'included_years' );
+		$start_date            = $request->get_param( 'start_date' );
+		$end_date              = $request->get_param( 'end_date' );
+		$agenda_link_label     = $request->get_param( 'agenda_link_label' ) ? $request->get_param( 'agenda_link_label' ) : __( 'View Agenda', 'boardscribe' );
+		$minutes_link_label    = $request->get_param( 'minutes_link_label' ) ? $request->get_param( 'minutes_link_label' ) : __( 'View Minutes', 'boardscribe' );
+		$open_links_new_window = $request->get_param( 'open_links_new_window' );
 
 		$posts_per_page = (int) $posts_per_page;
 
@@ -225,10 +226,11 @@ class BoardScribeEndpoint {
 				$meetings[] = $this->build_meeting_row(
 					get_the_ID(),
 					[
-						'held_date_format'     => $held_date_format,
-						'not_held_date_format' => $not_held_date_format,
-						'agenda_link_label'    => $agenda_link_label,
-						'minutes_link_label'   => $minutes_link_label,
+						'held_date_format'      => $held_date_format,
+						'not_held_date_format'  => $not_held_date_format,
+						'agenda_link_label'     => $agenda_link_label,
+						'minutes_link_label'    => $minutes_link_label,
+						'open_links_new_window' => $open_links_new_window,
 					],
 					$request
 				);
@@ -271,10 +273,11 @@ class BoardScribeEndpoint {
 	 * @param array                 $format_args {
 	 *    Formatting options.
 	 *
-	 *     @type string $held_date_format     PHP date() format for held meetings.
-	 *     @type string $not_held_date_format PHP date() format for not-held meetings.
-	 *     @type string $agenda_link_label    Link text for the agenda link.
-	 *     @type string $minutes_link_label   Link text for the minutes link.
+	 *     @type string $held_date_format      PHP date() format for held meetings.
+	 *     @type string $not_held_date_format  PHP date() format for not-held meetings.
+	 *     @type string $agenda_link_label     Link text for the agenda link.
+	 *     @type string $minutes_link_label    Link text for the minutes link.
+	 *     @type bool   $open_links_new_window Whether the agenda/minutes links open in a new window.
 	 * }
 	 * @param \WP_REST_Request|null $request     The originating REST request, if any.
 	 * @return array
@@ -317,31 +320,19 @@ class BoardScribeEndpoint {
 		$filtered_date  = apply_filters( 'edbs_meeting_formatted_date', $formatted_date, $post_id, $meeting_not_held );
 		$formatted_date = is_string( $filtered_date ) ? wp_kses_post( $filtered_date ) : $formatted_date;
 
+		$open_links_new_window = ! empty( $format_args['open_links_new_window'] );
+
 		$agenda_item = $agenda_url
 			? apply_filters(
 				'edbs_agenda_link',
-				'<a href="' . esc_url( $agenda_url ) . '" aria-label="' . esc_attr(
-					sprintf(
-					/* translators: 1: link label e.g. "View Agenda", 2: meeting date */
-						__( '%1$s for %2$s', 'boardscribe' ),
-						$agenda_link_label,
-						wp_strip_all_tags( $formatted_date )
-					)
-				) . '">' . esc_html( $agenda_link_label ) . '</a>'
+				self::build_link( $agenda_url, $agenda_link_label, $formatted_date, $open_links_new_window )
 			)
 			: '<span class="sr-text screen-reader-text">' . esc_html__( 'Agenda not available', 'boardscribe' ) . '</span>';
 
 		$minutes_item = $minutes_url
 			? apply_filters(
 				'edbs_minutes_link',
-				'<a href="' . esc_url( $minutes_url ) . '" aria-label="' . esc_attr(
-					sprintf(
-					/* translators: 1: link label e.g. "View Minutes", 2: meeting date */
-						__( '%1$s for %2$s', 'boardscribe' ),
-						$minutes_link_label,
-						wp_strip_all_tags( $formatted_date )
-					)
-				) . '">' . esc_html( $minutes_link_label ) . '</a>'
+				self::build_link( $minutes_url, $minutes_link_label, $formatted_date, $open_links_new_window )
 			)
 			: '<span class="sr-text screen-reader-text">' . esc_html__( 'Minutes not available', 'boardscribe' ) . '</span>';
 
@@ -363,6 +354,32 @@ class BoardScribeEndpoint {
 		 * @param \WP_REST_Request|null $request  The REST request, if any.
 		 */
 		return apply_filters( 'edbs_meeting_row_data', $row, $post_id, $request );
+	}
+
+	/**
+	 * Builds one agenda/minutes anchor tag. When $new_window is true, adds
+	 * target="_blank" and an aria-label suffix warning screen reader users
+	 * before they activate it, per WCAG 3.2.2 / Technique H83 — accessibility-checker's
+	 * own link_blank rule flags target="_blank" without this warning.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url            The agenda/minutes URL.
+	 * @param string $label          Visible link text.
+	 * @param string $formatted_date Escaped, formatted meeting date (used in the aria-label).
+	 * @param bool   $new_window     Whether to open the link in a new window/tab.
+	 * @return string
+	 */
+	private static function build_link( string $url, string $label, string $formatted_date, bool $new_window ): string {
+		$aria_label = $new_window
+			/* translators: 1: link label e.g. "View Agenda", 2: meeting date */
+			? sprintf( __( '%1$s for %2$s (opens in a new window)', 'boardscribe' ), $label, wp_strip_all_tags( $formatted_date ) )
+			/* translators: 1: link label e.g. "View Agenda", 2: meeting date */
+			: sprintf( __( '%1$s for %2$s', 'boardscribe' ), $label, wp_strip_all_tags( $formatted_date ) );
+
+		return '<a href="' . esc_url( $url ) . '"'
+			. ( $new_window ? ' target="_blank" rel="noopener noreferrer"' : '' )
+			. ' aria-label="' . esc_attr( $aria_label ) . '">' . esc_html( $label ) . '</a>';
 	}
 
 	/**

--- a/includes/Shortcode/FieldRegistry.php
+++ b/includes/Shortcode/FieldRegistry.php
@@ -272,6 +272,15 @@ class FieldRegistry {
 					'rest_arg' => true,
 				],
 				[
+					'key'         => 'open_links_new_window',
+					'type'        => self::TYPE_CHECKBOX,
+					'group'       => 'link_labels',
+					'label'       => __( 'Open Agenda/Minutes Links in a New Window', 'boardscribe' ),
+					'default'     => false,
+					'description' => __( 'Adds a screen-reader hint to each link when enabled, per WCAG 3.2.2.', 'boardscribe' ),
+					'rest_arg'    => true,
+				],
+				[
 					'key'     => 'hide_title',
 					'type'    => self::TYPE_CHECKBOX,
 					'group'   => 'hide_columns',

--- a/tests/phpunit/BoardScribeEndpointBuildRowTest.php
+++ b/tests/phpunit/BoardScribeEndpointBuildRowTest.php
@@ -210,6 +210,51 @@ class BoardScribeEndpointBuildRowTest extends TestCase {
 	}
 
 	/**
+	 * With open_links_new_window unset (default), agenda/minutes links
+	 * have no target attribute.
+	 */
+	public function test_links_do_not_open_new_window_by_default(): void {
+		$post_id = $this->create_meeting(
+			[
+				'edbs_meeting_date' => '2024-03-15',
+				'edbs_agenda_url'   => 'https://example.com/agenda.pdf',
+			]
+		);
+
+		$row = $this->endpoint->build_meeting_row( $post_id, $this->default_format_args );
+
+		$this->assertStringNotContainsString( 'target="_blank"', $row['agenda'] );
+	}
+
+	/**
+	 * With open_links_new_window enabled, agenda/minutes links get
+	 * target="_blank", rel="noopener noreferrer", and an aria-label
+	 * warning screen reader users before they activate the link.
+	 */
+	public function test_links_open_new_window_when_enabled(): void {
+		$post_id = $this->create_meeting(
+			[
+				'edbs_meeting_date' => '2024-03-15',
+				'edbs_agenda_url'   => 'https://example.com/agenda.pdf',
+				'edbs_minutes_url'  => 'https://example.com/minutes.pdf',
+			]
+		);
+
+		$row = $this->endpoint->build_meeting_row(
+			$post_id,
+			array_merge( $this->default_format_args, [ 'open_links_new_window' => true ] )
+		);
+
+		$this->assertStringContainsString( 'target="_blank"', $row['agenda'] );
+		$this->assertStringContainsString( 'rel="noopener noreferrer"', $row['agenda'] );
+		$this->assertStringContainsString( 'opens in a new window', $row['agenda'] );
+
+		$this->assertStringContainsString( 'target="_blank"', $row['minutes'] );
+		$this->assertStringContainsString( 'rel="noopener noreferrer"', $row['minutes'] );
+		$this->assertStringContainsString( 'opens in a new window', $row['minutes'] );
+	}
+
+	/**
 	 * Calling build_meeting_row() with no $request (e.g. from a future
 	 * non-REST caller like a CSV export) does not throw.
 	 */


### PR DESCRIPTION
## Summary
- Adds an "Open Agenda/Minutes Links in a New Window" checkbox to the shortcode builder and the Board Meetings block (`link_labels` group), for both the `[edbs_boardscribe]` shortcode and the block.
- Off by default — existing shortcodes/blocks render exactly as before.
- When enabled, agenda/minutes links get `target="_blank" rel="noopener noreferrer"` plus an aria-label suffix ("...opens in a new window"), matching WCAG 3.2.2 / Technique H83 — the same convention accessibility-checker's own `link_blank` rule recommends.
- Because `FieldRegistry` is the single source of truth for shortcode/block/REST/builder fields, and `rest_arg_map()` (from the recent "forward rest_arg fields dynamically" work on `develop`) already forwards any `rest_arg` field to the front-end request automatically, adding one field descriptor was enough to wire up the shortcode attribute, block attribute + InspectorControls, REST arg, builder-UI checkbox, and request forwarding — no JS changes needed.
- Extracted `BoardScribeEndpoint::build_link()` so the agenda and minutes links share one link-building implementation instead of two near-identical blocks.

## Test plan
- [x] `composer test` — 158 tests, 306 assertions, all passing (includes 2 new tests: default has no `target` attribute; enabled adds `target="_blank"`, `rel="noopener noreferrer"`, and the aria-label hint)
- [x] `npx wp-scripts test-unit-js` — 17 tests passing (no JS changes needed, verified no regressions)
- [x] `phpcs` clean on all changed files
- [x] Manually verified live on a local WP site:
  - Shortcode builder: toggle appears in Link Labels panel, generates `[edbs_boardscribe open_links_new_window="true"]`, live preview updates with `target="_blank"` + aria-label
  - Block editor: same toggle in InspectorControls, server-rendered preview reflects it
  - REST endpoint: `?open_links_new_window=1` returns the new markup; omitted/false returns unchanged markup
- [ ] Reviewer: spot-check the rendered aria-label text reads naturally with a screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GELbDfhE991PTTkQf6iq7h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to open meeting agenda and minutes links in a new browser window or tab.
  - The option is disabled by default and can be enabled through the available settings.
  - Links opened in a new window include security protections and an accessibility notice for screen readers.
  - The setting applies consistently to both editor previews and REST-generated meeting listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->