### PR TITLE
Make the block editor preview table scroll horizontally

### DIFF
--- a/partials/block-editor-preview.php
+++ b/partials/block-editor-preview.php
@@ -18,43 +18,45 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<table
-	class="edbs-boardscribe-table widefat"
-	style="border-collapse:collapse;<?php echo $equal_columns ? ' table-layout:fixed;' : ''; ?>"
->
-	<thead>
-		<tr>
-			<?php foreach ( $visible_columns as $edbs_column ) : ?>
-				<th scope="col" style="padding:8px 12px; text-align:left;"><?php echo esc_html( $edbs_column['label'] ?? '' ); ?></th>
-			<?php endforeach; ?>
-		</tr>
-	</thead>
-	<tbody>
-		<?php if ( $rows ) : ?>
-			<?php foreach ( $rows as $edbs_entry ) : ?>
-				<tr style="border-top:1px solid #ddd;">
-					<?php foreach ( $visible_columns as $edbs_column ) : ?>
-						<td style="padding:8px 12px;">
-							<?php
-							// render_cell() output is pre-escaped HTML by documented
-							// contract (see the edbs_block_preview_columns filter) -
-							// the same trust contract as the front end's
-							// window.edbsExtraColumns renderCell().
-							echo call_user_func( $edbs_column['render_cell'], $edbs_entry['row'], $edbs_entry['post'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							?>
-						</td>
-					<?php endforeach; ?>
-				</tr>
-			<?php endforeach; ?>
-		<?php else : ?>
+<div style="overflow-x:auto;">
+	<table
+		class="edbs-boardscribe-table widefat"
+		style="border-collapse:collapse;<?php echo $equal_columns ? ' table-layout:fixed;' : ''; ?>"
+	>
+		<thead>
 			<tr>
-				<td
-					colspan="<?php echo esc_attr( count( $visible_columns ) ); ?>"
-					style="padding:16px 12px; color:#757575; font-style:italic;"
-				>
-					<?php esc_html_e( 'No published meetings found.', 'boardscribe' ); ?>
-				</td>
+				<?php foreach ( $visible_columns as $edbs_column ) : ?>
+					<th scope="col" style="padding:8px 12px; text-align:left;"><?php echo esc_html( $edbs_column['label'] ?? '' ); ?></th>
+				<?php endforeach; ?>
 			</tr>
-		<?php endif; ?>
-	</tbody>
-</table>
+		</thead>
+		<tbody>
+			<?php if ( $rows ) : ?>
+				<?php foreach ( $rows as $edbs_entry ) : ?>
+					<tr style="border-top:1px solid #ddd;">
+						<?php foreach ( $visible_columns as $edbs_column ) : ?>
+							<td style="padding:8px 12px;">
+								<?php
+								// render_cell() output is pre-escaped HTML by documented
+								// contract (see the edbs_block_preview_columns filter) -
+								// the same trust contract as the front end's
+								// window.edbsExtraColumns renderCell().
+								echo call_user_func( $edbs_column['render_cell'], $edbs_entry['row'], $edbs_entry['post'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								?>
+							</td>
+						<?php endforeach; ?>
+					</tr>
+				<?php endforeach; ?>
+			<?php else : ?>
+				<tr>
+					<td
+						colspan="<?php echo esc_attr( count( $visible_columns ) ); ?>"
+						style="padding:16px 12px; color:#757575; font-style:italic;"
+					>
+						<?php esc_html_e( 'No published meetings found.', 'boardscribe' ); ?>
+					</td>
+				</tr>
+			<?php endif; ?>
+		</tbody>
+	</table>
+</div>

--- a/tests/phpunit/BoardScribeBlockPreviewScrollTest.php
+++ b/tests/phpunit/BoardScribeBlockPreviewScrollTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tests for BoardScribeBlock::render_preview_table()'s horizontal-scroll wrapper.
+ *
+ * @package EqualizeDigital\BoardScribe
+ */
+
+use EqualizeDigital\BoardScribe\Block\BoardScribeBlock;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers PRO-1202: a wide preview table (many visible columns, or long
+ * unbreakable cell content) must scroll horizontally within the block
+ * editor's preview container instead of overflowing it.
+ */
+class BoardScribeBlockPreviewScrollTest extends TestCase {
+
+	/**
+	 * A single-column table wrapped in a horizontally scrollable container.
+	 */
+	public function test_preview_table_is_wrapped_in_a_scroll_container(): void {
+		$block = new BoardScribeBlock();
+
+		$html = $block->render_preview_table(
+			[
+				'title' => [
+					'label'       => 'Title',
+					'render_cell' => static fn(): string => 'A Meeting',
+				],
+			],
+			[],
+			[]
+		);
+
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*style="[^"]*overflow-x:\s*auto[^"]*"[^>]*>\s*<table/',
+			$html
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Closes PRO-1202. The block editor's server-rendered preview table (`partials/block-editor-preview.php`) had no width constraint and broke out of the preview container when it had many visible columns (e.g. with several of Pro's optional columns — location, livestream, recording, cc_transcript, documents — enabled) or long unbreakable cell content.
- Wraps the `<table>` in a `<div style="overflow-x:auto;">`, so it scrolls horizontally within its own container instead of overflowing the editor canvas.
- Fixes every caller of `render_preview_table()`, including Pro's year-timeline template, which renders this same partial once per year group.
- The front-end table (shortcode/live block output) already has separate responsive handling — it stacks into cards below 768px — so this is scoped to the editor preview only, per the issue.

## Test plan
- [x] `composer test` — 157 tests, 300 assertions, all passing (includes 1 new test asserting the table is wrapped in an `overflow-x:auto` container)
- [x] `phpcs` clean
- [x] Manually verified live in the block editor on a local WP site: enabled several Pro "Show Columns" so the table exceeds the block's width — confirmed via DOM inspection that the wrapper's `scrollWidth` (747px) exceeds its `clientWidth` (645px) with `overflow-x:auto` active, and that the editor canvas itself has no overflow (`body.scrollWidth === body.clientWidth`) — i.e. the table scrolls within its own container instead of breaking out of the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GELbDfhE991PTTkQf6iq7h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preview tables now support horizontal scrolling on smaller screens.

- **Tests**
  - Added coverage to verify the horizontally scrollable preview table container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->