### PR TITLE
Add InstaWP deploy-on-release workflow

### DIFF
--- a/.github/workflows/deploy-on-release-to-instawp.yml
+++ b/.github/workflows/deploy-on-release-to-instawp.yml
@@ -1,0 +1,126 @@
+name: Deploy to InstaWP
+
+on:
+  workflow_run:
+    workflows: ["Build BoardScribe Plugin + Playground Link"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      plugin_zip_path:
+        description: 'Path to the plugin zip file to deploy. Must be a zip file.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'release'
+      )
+
+    steps:
+      - name: Get release asset
+        id: get_release_assets
+        if: github.event_name == 'workflow_run'
+        run: |
+          RELEASES_URL="https://api.github.com/repos/${{ github.repository }}/releases"
+          echo "Fetching releases from: $RELEASES_URL"
+
+          RELEASE=$(curl -s \
+            -H "Authorization: token ${{ github.token }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "$RELEASES_URL?per_page=5" | jq -c '[.[] | select(.draft == false)][0]')
+
+          if [[ -z "$RELEASE" || "$RELEASE" == "null" ]]; then
+            echo "No published release found."
+            exit 1
+          fi
+
+          RELEASE_TAG=$(echo "$RELEASE" | jq -r '.tag_name')
+          echo "Using release tag: $RELEASE_TAG"
+
+          ZIP_URL=$(echo "$RELEASE" | jq -r '.assets[]
+            | select(.name | test("^boardscribe-[0-9].*\\.zip$"))
+            | .browser_download_url' | head -n 1)
+
+          if [[ -z "$ZIP_URL" ]]; then
+            echo "No boardscribe zip file found in release assets."
+            exit 1
+          fi
+
+          echo "Found boardscribe zip file: $ZIP_URL"
+          echo "zip_url=$ZIP_URL" >> $GITHUB_OUTPUT
+
+      - name: Download and validate plugin zip file
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            ZIP_URL="${{ steps.get_release_assets.outputs.zip_url }}"
+          else
+            ZIP_URL="${{ github.event.inputs.plugin_zip_path }}"
+          fi
+
+          echo "Using ZIP_URL: $ZIP_URL"
+
+          ZIP_NAME=$(basename "$ZIP_URL")
+          curl -L "$ZIP_URL" -o "$ZIP_NAME"
+          if [ ! -f "$ZIP_NAME" ]; then
+            echo "File does not exist: $ZIP_NAME"
+            exit 1
+          fi
+          if [[ "$ZIP_NAME" != *.zip ]]; then
+            echo "File does not have .zip extension: $ZIP_NAME"
+            exit 1
+          fi
+          MIME_TYPE=$(file --mime-type -b "$ZIP_NAME")
+          if [ "$MIME_TYPE" != "application/zip" ]; then
+            echo "File is not a valid zip archive: $ZIP_NAME (type: $MIME_TYPE)"
+            exit 1
+          fi
+
+      - name: Deploy to InstaWP
+        run: |
+          API_KEY=${{ secrets.INSTAWP_API_KEY }}
+          SITE_ID_BOARDSCRIBE=${{ secrets.INSTAWP_SITE_ID_BOARDSCRIBE }}
+
+          # Skip rather than fail while the InstaWP site is still being
+          # provisioned - a release shouldn't go red over a deploy target
+          # that doesn't exist yet.
+          if [[ -z "$API_KEY" || -z "$SITE_ID_BOARDSCRIBE" ]]; then
+            echo "INSTAWP_API_KEY / INSTAWP_SITE_ID_BOARDSCRIBE not set yet - skipping InstaWP deploy."
+            exit 0
+          fi
+
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            PLUGIN_URL="${{ steps.get_release_assets.outputs.zip_url }}"
+          else
+            PLUGIN_URL="${{ github.event.inputs.plugin_zip_path }}"
+          fi
+
+          echo "Deploying plugin from: $PLUGIN_URL"
+          echo "Deploying to InstaWP site ID: $SITE_ID_BOARDSCRIBE"
+          HTTP_CODE=$(curl -sS -o /tmp/instawp-response.json -w "%{http_code}" \
+            -X POST "https://app.instawp.io/api/v2/sites/$SITE_ID_BOARDSCRIBE/execute-command" \
+            -H "Authorization: Bearer $API_KEY" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"command_id\": 2623,
+              \"commandArguments\": [
+                {\"PLUGIN_STRING\": \"$PLUGIN_URL\"}
+              ]
+            }")
+
+          if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+            echo "InstaWP deploy failed for site $SITE_ID_BOARDSCRIBE (HTTP $HTTP_CODE)"
+            cat /tmp/instawp-response.json
+            exit 1
+          fi
+
+          echo "InstaWP deploy succeeded for site $SITE_ID_BOARDSCRIBE"


### PR DESCRIPTION
## Summary
- Adds `deploy-on-release-to-instawp.yml`, mirroring `accessibility-checker`'s workflow of the same name (both repos are public, so no signed-URL step needed here — the plain release asset URL works).
- Triggers on the existing "Build BoardScribe Plugin + Playground Link" workflow completing for a `release` event, fetches the release's `boardscribe-{version}.zip` asset, and pushes it to an InstaWP site via InstaWP's execute-command API.
- Also accepts `workflow_dispatch` with an explicit zip URL, matching the sibling repos' pattern.
- Targets one InstaWP site via a new `INSTAWP_SITE_ID_BOARDSCRIBE` secret — the same site `boardscribe-pro`'s and `accessibility-checker`'s deploy workflows target, so all three plugins land on one shared demo/test site.

## Not yet configured
- `INSTAWP_API_KEY` and `INSTAWP_SITE_ID_BOARDSCRIBE` repo secrets aren't set yet — the deploy step detects that and exits 0 with a log message rather than failing the workflow, so releases aren't blocked in the meantime. Once the InstaWP site exists, add those two secrets and deploys start working with no further code change.

## Test plan
- [x] YAML syntax validated
- [x] Manually traced against the already-working `accessibility-checker` version this is modeled on
- [ ] First real release once merged, to confirm the release-asset zip-name pattern (`^boardscribe-[0-9].*\.zip$`) matches what the build workflow actually produces
- [ ] Add `INSTAWP_API_KEY` / `INSTAWP_SITE_ID_BOARDSCRIBE` secrets once the site exists, then re-run to confirm the deploy actually lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GELbDfhE991PTTkQf6iq7h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automated deployment to InstaWP is now available after successful release builds.
  - Deployments can also be triggered manually with a specified release package.
  - Validation and error handling help prevent deployments when required release files, credentials, or site settings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->