### PR TITLE
Fix parse_date() silently accepting overflow-mangled d/m/Y dates

### DIFF
--- a/includes/REST/BoardScribeEndpoint.php
+++ b/includes/REST/BoardScribeEndpoint.php
@@ -403,6 +403,16 @@ class BoardScribeEndpoint {
 	 * Supports Y-m-d (native/ISO), Ymd (ACF default), d/m/Y and m/d/Y
 	 * to handle data previously stored by ACF with varying format settings.
 	 *
+	 * Each format's shape is checked with a strict regex before construction,
+	 * and its extracted day/month/year validated with checkdate(), rather
+	 * than handed straight to DateTime::createFromFormat(). That function is
+	 * lenient about out-of-range values within a format (e.g. month 15 rolls
+	 * over into the next year instead of failing), so trying d/m/Y before
+	 * m/d/Y could otherwise silently misdate an m/d/Y value with day > 12 -
+	 * e.g. "03/15/2023" (March 15) rolling over to 2024-03-03 under d/m/Y
+	 * before m/d/Y is ever tried. Validating first means only a format whose
+	 * components are genuinely in range is ever accepted.
+	 *
 	 * Public and static so Pro features that derive values from the raw
 	 * edbs_meeting_date meta (e.g. year grouping) parse the stored value
 	 * with the exact same format list as this endpoint, instead of
@@ -418,7 +428,27 @@ class BoardScribeEndpoint {
 			return null;
 		}
 
-		foreach ( [ 'Y-m-d', 'Ymd', 'd/m/Y', 'm/d/Y' ] as $format ) {
+		// [ format => [ regex, day group, month group, year group ] ].
+		// Groups are fixed-width to match what each format's picker actually
+		// stores (zero-padded day/month, 4-digit year) - not a general date
+		// parser, just enough to disambiguate this plugin's own legacy
+		// storage formats.
+		$formats = [
+			'Y-m-d' => [ '/^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/', 'day', 'month', 'year' ],
+			'Ymd'   => [ '/^(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})$/', 'day', 'month', 'year' ],
+			'd/m/Y' => [ '/^(?<day>\d{2})\/(?<month>\d{2})\/(?<year>\d{4})$/', 'day', 'month', 'year' ],
+			'm/d/Y' => [ '/^(?<month>\d{2})\/(?<day>\d{2})\/(?<year>\d{4})$/', 'day', 'month', 'year' ],
+		];
+
+		foreach ( $formats as $format => [ $regex, $day_key, $month_key, $year_key ] ) {
+			if ( ! preg_match( $regex, $date_string, $matches ) ) {
+				continue;
+			}
+
+			if ( ! checkdate( (int) $matches[ $month_key ], (int) $matches[ $day_key ], (int) $matches[ $year_key ] ) ) {
+				continue;
+			}
+
 			$date = \DateTime::createFromFormat( $format, $date_string );
 			if ( false !== $date ) {
 				return $date;

--- a/tests/phpunit/BoardScribeEndpointParseDateTest.php
+++ b/tests/phpunit/BoardScribeEndpointParseDateTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for BoardScribeEndpoint::parse_date().
+ *
+ * @package EqualizeDigital\BoardScribe
+ */
+
+use EqualizeDigital\BoardScribe\REST\BoardScribeEndpoint;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Covers PRO-1309: DateTime::createFromFormat() is lenient about
+ * out-of-range values (a month of 15 rolls over into the next year
+ * instead of failing), so trying the four supported formats in order
+ * could previously misdate a value stored in one format by accepting it
+ * under an earlier, wrong format whose overflow happened to "succeed".
+ */
+class BoardScribeEndpointParseDateTest extends TestCase {
+
+	/**
+	 * Each supported format parses its own values correctly.
+	 *
+	 * @dataProvider provide_valid_dates
+	 * @param string $input    Raw date string.
+	 * @param string $expected Expected Y-m-d result.
+	 */
+	public function test_parses_valid_dates( string $input, string $expected ): void {
+		$date = BoardScribeEndpoint::parse_date( $input );
+
+		$this->assertNotNull( $date );
+		$this->assertSame( $expected, $date->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * Data provider for valid dates, one per supported format.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function provide_valid_dates(): array {
+		return [
+			'Y-m-d (ISO)'          => [ '2023-03-15', '2023-03-15' ],
+			'Ymd (ACF default)'    => [ '20230315', '2023-03-15' ],
+			'd/m/Y, day <= 12'     => [ '05/03/2023', '2023-03-05' ],
+			'm/d/Y, day > 12'      => [ '03/15/2023', '2023-03-15' ],
+		];
+	}
+
+	/**
+	 * The exact regression from PRO-1309: a legacy m/d/Y value with a day
+	 * greater than 12 must resolve to the date it actually represents
+	 * (March 15, 2023), not silently roll over to a different date
+	 * (2024-03-03) by being misparsed under d/m/Y first.
+	 */
+	public function test_does_not_misdate_overflow_ambiguous_value(): void {
+		$date = BoardScribeEndpoint::parse_date( '03/15/2023' );
+
+		$this->assertNotNull( $date );
+		$this->assertSame( '2023-03-15', $date->format( 'Y-m-d' ) );
+		$this->assertNotSame( '2024-03-03', $date->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * A value that isn't a valid date under any supported format - not
+	 * just out of range for one format, genuinely invalid everywhere
+	 * (month 13, no format has a 13th month) - returns null instead of
+	 * an overflow-mangled DateTime.
+	 */
+	public function test_rejects_a_date_invalid_in_every_format(): void {
+		$this->assertNull( BoardScribeEndpoint::parse_date( '2023-13-45' ) );
+	}
+
+	/**
+	 * A day/month combination invalid in both slash formats (e.g. 13 is
+	 * not a valid month, and swapping it to a day of 13 with month 13
+	 * doesn't help either) returns null rather than picking whichever
+	 * format DateTime::createFromFormat() happens to overflow into a
+	 * plausible-looking date.
+	 */
+	public function test_rejects_ambiguous_slash_date_invalid_both_ways(): void {
+		$this->assertNull( BoardScribeEndpoint::parse_date( '13/13/2023' ) );
+	}
+
+	/**
+	 * Feb 30 is invalid in Y-m-d regardless of leniency elsewhere.
+	 */
+	public function test_rejects_nonexistent_calendar_date(): void {
+		$this->assertNull( BoardScribeEndpoint::parse_date( '2023-02-30' ) );
+	}
+
+	/**
+	 * An empty string returns null without attempting to parse.
+	 */
+	public function test_empty_string_returns_null(): void {
+		$this->assertNull( BoardScribeEndpoint::parse_date( '' ) );
+	}
+
+	/**
+	 * Garbage input that matches no supported format's shape at all
+	 * returns null rather than throwing.
+	 */
+	public function test_unrecognized_format_returns_null(): void {
+		$this->assertNull( BoardScribeEndpoint::parse_date( 'not a date' ) );
+	}
+
+	/**
+	 * A leap day is accepted in a leap year...
+	 */
+	public function test_accepts_leap_day_in_leap_year(): void {
+		$date = BoardScribeEndpoint::parse_date( '2024-02-29' );
+
+		$this->assertNotNull( $date );
+		$this->assertSame( '2024-02-29', $date->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * ...and rejected in a non-leap year, rather than rolling over to
+	 * March 1st.
+	 */
+	public function test_rejects_leap_day_in_non_leap_year(): void {
+		$this->assertNull( BoardScribeEndpoint::parse_date( '2023-02-29' ) );
+	}
+}


### PR DESCRIPTION
Closes #92 / PRO-1309.

## Summary
`BoardScribeEndpoint::parse_date()` tried formats in order (`Y-m-d`, `Ymd`, `d/m/Y`, `m/d/Y`) and accepted the first one `DateTime::createFromFormat()` didn't return `false` for. But that function is lenient about out-of-range values within a format — a month of 15 rolls over into the next year instead of failing — so it doesn't reliably reject a wrong format.

Concretely: a legacy value intended as `m/d/Y` with day > 12, e.g. `03/15/2023` (March 15, 2023), was tried against `d/m/Y` first (day=03, month=15). Month 15 overflows: 15 − 12 = 3, year + 1 → silently accepted as **2024-03-03**, a completely different date, with only a PHP warning `parse_date()` never checked for.

## Fix
Each format's shape is now checked with a strict regex, and its extracted day/month/year validated with `checkdate()`, before `DateTime::createFromFormat()` is ever called — so only a format whose components are genuinely in range gets accepted. No round-tripping or `getLastErrors()` parsing needed, and it sidesteps the zero-padding ambiguity a reformat-and-compare approach would have.

`parse_date()` is `public static` and used by every date-display path in the plugin (row date display, editor preview, admin columns, meta box) plus Pro's own date derivation, per its docblock — this fix is scoped to just that shared method, with its own regression coverage, per the issue's scope note.

## Test plan
- [x] New `BoardScribeEndpointParseDateTest` — 12 tests covering: one valid case per format, the exact PRO-1309 regression (`03/15/2023` → `2023-03-15`, not `2024-03-03`), a date invalid in every format, a slash-date invalid both ways (13/13), a nonexistent calendar date (Feb 30), empty string, unrecognized shape, and leap-year Feb 29 accept/reject
- [x] Full suite: 169 tests, 319 assertions, all passing (no regressions)
- [x] `phpcs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GELbDfhE991PTTkQf6iq7h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Date inputs are now validated more strictly, preventing invalid, ambiguous, or nonexistent dates from being incorrectly interpreted.
  - Leap-year dates are handled correctly, while invalid leap days are rejected.

- **Tests**
  - Added coverage for supported date formats, invalid calendar dates, ambiguous values, empty input, unrecognized formats, and leap-year behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->