### PR TITLE
feat: restyle the CSV import upload section

### DIFF
--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -294,3 +294,65 @@ body.edbs_meeting_page_edbs-settings {
 	margin: 0 0 12px;
 	break-inside: avoid;
 }
+
+/* Import tab: CSV upload form, sized to match the CSV format table above it. */
+.edbs-import__format-table,
+.edbs-import__upload {
+	max-width: 600px;
+}
+
+.edbs-import__format-table {
+	margin-bottom: 24px;
+}
+
+.edbs-import__upload {
+	margin-top: 24px;
+}
+
+.edbs-import__upload-header {
+	margin-bottom: 16px;
+}
+
+.edbs-import__upload-title {
+	margin: 0 0 6px;
+	color: var(--edbs-gray-darkest);
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.edbs-import__upload-description {
+	margin: 0;
+	color: var(--edbs-dark-gray);
+	font-size: 0.875rem;
+}
+
+.edbs-import__file-upload {
+	margin-bottom: 20px;
+}
+
+.edbs-import__file-label {
+	display: block;
+	margin-bottom: 6px;
+	color: var(--edbs-gray-darkest);
+	font-size: 0.875rem;
+	font-weight: 600;
+}
+
+.edbs-import__file-upload input[type="file"] {
+	display: block;
+	width: 100%;
+	/* Capped so the dashed field doesn't dwarf the small native control. */
+	max-width: 440px;
+	padding: 10px 12px;
+	background: var(--edbs-misty);
+	border: 1px dashed var(--edbs-gray-light);
+	border-radius: 4px;
+	font-size: 0.875rem;
+	cursor: pointer;
+	box-sizing: border-box;
+}
+
+.edbs-import__file-upload input[type="file"]:focus {
+	outline: 2px solid var(--edbs-blue);
+	outline-offset: 2px;
+}

--- a/partials/csv-import-page.php
+++ b/partials/csv-import-page.php
@@ -72,7 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input type="hidden" name="action" value="edbs_csv_import" />
 		<div class="edbs-import__upload-header">
 			<h2 id="edbs-import-heading" class="edbs-import__upload-title"><?php esc_html_e( 'Upload CSV', 'boardscribe' ); ?></h2>
-			<p class="edbs-import__upload-description"><?php esc_html_e( 'Choose a file using the columns above. The first row must be a header row, and each row after it creates one meeting.', 'boardscribe' ); ?></p>
+			<p class="edbs-import__upload-description"><?php esc_html_e( 'Choose a file using the columns above. The first row must be a header row, and each valid row after it creates one meeting.', 'boardscribe' ); ?></p>
 		</div>
 		<div class="edbs-import__file-upload">
 			<label for="edbs_csv" class="edbs-import__file-label"><?php esc_html_e( 'CSV file', 'boardscribe' ); ?></label>

--- a/partials/csv-import-page.php
+++ b/partials/csv-import-page.php
@@ -45,10 +45,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php endif; ?>
 	<?php // phpcs:enable WordPress.Security.NonceVerification.Recommended ?>
 
-	<p><?php esc_html_e( 'Upload a CSV file to bulk-import meetings. The first row must be a header row.', 'boardscribe' ); ?></p>
+	<p><?php esc_html_e( 'Upload a CSV file to bulk-import meetings.', 'boardscribe' ); ?></p>
 
 	<h2><?php esc_html_e( 'CSV Format', 'boardscribe' ); ?></h2>
-	<table class="widefat striped" style="max-width:600px; margin-bottom:24px;">
+	<table class="widefat striped edbs-import__format-table">
 		<thead>
 			<tr>
 				<th><?php esc_html_e( 'Column', 'boardscribe' ); ?></th>
@@ -67,21 +67,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</tbody>
 	</table>
 
-	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" aria-labelledby="edbs-import-heading" class="edbs-import__upload">
 		<?php wp_nonce_field( 'edbs_csv_import', 'edbs_csv_import_nonce' ); ?>
 		<input type="hidden" name="action" value="edbs_csv_import" />
-		<table class="form-table" role="presentation">
-			<tbody>
-				<tr>
-					<th scope="row">
-						<label for="edbs_csv"><?php esc_html_e( 'CSV File', 'boardscribe' ); ?></label>
-					</th>
-					<td>
-						<input type="file" id="edbs_csv" name="edbs_csv" accept=".csv,text/csv" required />
-					</td>
-				</tr>
-			</tbody>
-		</table>
-		<?php submit_button( __( 'Import', 'boardscribe' ) ); ?>
+		<div class="edbs-import__upload-header">
+			<h2 id="edbs-import-heading" class="edbs-import__upload-title"><?php esc_html_e( 'Upload CSV', 'boardscribe' ); ?></h2>
+			<p class="edbs-import__upload-description"><?php esc_html_e( 'Choose a file using the columns above. The first row must be a header row, and each row after it creates one meeting.', 'boardscribe' ); ?></p>
+		</div>
+		<div class="edbs-import__file-upload">
+			<label for="edbs_csv" class="edbs-import__file-label"><?php esc_html_e( 'CSV file', 'boardscribe' ); ?></label>
+			<input type="file" id="edbs_csv" name="edbs_csv" accept=".csv,text/csv" required />
+		</div>
+		<div class="edbs-import__actions">
+			<?php submit_button( __( 'Import Meetings', 'boardscribe' ), 'primary', 'submit', false ); ?>
+		</div>
 	</form>
 </div>


### PR DESCRIPTION
## Summary

Restyles the CSV File control at the bottom of the Import tab, which was a bare `form-table` row, into a labeled upload section modeled on the Accessibility Checker Pro import/export panel.

- Heading ("Upload CSV") + description, with `aria-labelledby` tying the form to that heading.
- Visible `CSV file` label and a dashed dropzone-style input, capped at 440px so the field doesn't dwarf the small native control.
- Submit button relabeled "Import Meetings" so the action names what it creates; it stays at its natural width.
- The format table's inline `max-width`/`margin-bottom` move into `.edbs-import__format-table`, so the table and the upload section share one 600px width declaration.

No box/border around the section: it renders inside `.edbs-settings-panel`, which is already white with the same 1px border, so a card there would read as border-on-border.

## Copy

The header-row requirement moved out of the tab intro and down next to the control it applies to:

- Intro: "Upload a CSV file to bulk-import meetings."
- Upload description: "Choose a file using the columns above. The first row must be a header row, and each row after it creates one meeting."

## Notes

Styles live in `assets/css/settings.css`, already enqueued for every settings tab, so no enqueue change. No PHP logic, hooks, or import behavior touched.

## Testing

- `composer lint` and `phpcs` clean (also run by the pre-commit hook).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the CSV import interface with clearer layout, spacing, headings, descriptions, and table formatting.
  - Added dedicated styling for the format table and upload form.
  - Improved file labeling, native file input presentation, and keyboard focus visibility.

- **Accessibility**
  - Added descriptive instructions explaining that each valid row after the header creates one meeting.
  - Added an accessible heading for the upload section.

- **Usability**
  - Updated the submit button label to “Import Meetings” for greater clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->